### PR TITLE
small osp chat improvements

### DIFF
--- a/Moblin/Platforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
+++ b/Moblin/Platforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
@@ -105,8 +105,8 @@ class OpenStreamingPlatformChat {
     init(model: Model, url: String, channelId: String) {
         self.model = model
         self.url = url
-        self.username = "moblin"
-        self.password = randomString()
+        username = "moblin"
+        password = randomString()
         self.channelId = channelId
         let url = URL(string: "ws://192.168.50.72:5443/ws")!
         webSocket = URLSession(configuration: .default).webSocketTask(with: url)

--- a/Moblin/Platforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
+++ b/Moblin/Platforms/OpenStreamingPlatform/OpenStreamingPlatformChat.swift
@@ -102,11 +102,11 @@ class OpenStreamingPlatformChat {
     private var authenticated = false
     private var jid: String = ""
 
-    init(model: Model, url: String, username: String, password: String, channelId: String) {
+    init(model: Model, url: String, channelId: String) {
         self.model = model
         self.url = url
-        self.username = username
-        self.password = password
+        self.username = "moblin"
+        self.password = randomString()
         self.channelId = channelId
         let url = URL(string: "ws://192.168.50.72:5443/ws")!
         webSocket = URLSession(configuration: .default).webSocketTask(with: url)

--- a/Moblin/RemoteControl/RemoteControlAssistant.swift
+++ b/Moblin/RemoteControl/RemoteControlAssistant.swift
@@ -15,10 +15,6 @@ private struct RemoteControlRequestResponse {
     let onError: (String) -> Void
 }
 
-private func randomString() -> String {
-    return Data.random(length: 64).base64EncodedString()
-}
-
 class RemoteControlAssistant {
     private let port: UInt16
     private let password: String

--- a/Moblin/Various/Model.swift
+++ b/Moblin/Various/Model.swift
@@ -2277,8 +2277,7 @@ final class Model: NSObject, ObservableObject {
     func isOpenStreamingPlatformChatConfigured() -> Bool {
         return database.chat.enabled! && stream.openStreamingPlatformEnabled! && stream
             .openStreamingPlatformUrl! != "" && stream
-            .openStreamingPlatformUsername! != "" && stream
-            .openStreamingPlatformPassword! != ""
+            .openStreamingPlatformChannelId! != ""
     }
 
     func isOpenStreamingPlatformChatConnected() -> Bool {
@@ -2407,8 +2406,6 @@ final class Model: NSObject, ObservableObject {
             openStreamingPlatformChat = OpenStreamingPlatformChat(
                 model: self,
                 url: stream.openStreamingPlatformUrl!,
-                username: stream.openStreamingPlatformUsername!,
-                password: stream.openStreamingPlatformPassword!,
                 channelId: stream.openStreamingPlatformChannelId!
             )
             openStreamingPlatformChat!.start()
@@ -2501,16 +2498,6 @@ final class Model: NSObject, ObservableObject {
     }
 
     func openStreamingPlatformUrlUpdated() {
-        reloadOpenStreamingPlatformChat()
-        resetChat()
-    }
-
-    func openStreamingPlatformUsernameUpdated() {
-        reloadOpenStreamingPlatformChat()
-        resetChat()
-    }
-
-    func openStreamingPlatformPasswordUpdated() {
         reloadOpenStreamingPlatformChat()
         resetChat()
     }

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -282,8 +282,6 @@ class SettingsStream: Codable, Identifiable, Equatable {
     var afreecaTvStreamId: String? = ""
     var openStreamingPlatformEnabled: Bool? = true
     var openStreamingPlatformUrl: String? = ""
-    var openStreamingPlatformUsername: String? = ""
-    var openStreamingPlatformPassword: String? = ""
     var openStreamingPlatformChannelId: String? = ""
     var obsWebSocketEnabled: Bool? = true
     var obsWebSocketUrl: String? = ""
@@ -328,8 +326,6 @@ class SettingsStream: Codable, Identifiable, Equatable {
         new.afreecaTvStreamId = afreecaTvStreamId
         new.openStreamingPlatformEnabled = openStreamingPlatformEnabled
         new.openStreamingPlatformUrl = openStreamingPlatformUrl
-        new.openStreamingPlatformUsername = openStreamingPlatformUsername
-        new.openStreamingPlatformPassword = openStreamingPlatformPassword
         new.openStreamingPlatformChannelId = openStreamingPlatformChannelId
         new.obsWebSocketEnabled = obsWebSocketEnabled
         new.obsWebSocketUrl = obsWebSocketUrl
@@ -2227,14 +2223,6 @@ final class Settings {
         }
         for stream in realDatabase.streams where stream.openStreamingPlatformUrl == nil {
             stream.openStreamingPlatformUrl = ""
-            store()
-        }
-        for stream in realDatabase.streams where stream.openStreamingPlatformUsername == nil {
-            stream.openStreamingPlatformUsername = ""
-            store()
-        }
-        for stream in realDatabase.streams where stream.openStreamingPlatformPassword == nil {
-            stream.openStreamingPlatformPassword = ""
             store()
         }
         for stream in realDatabase.streams where stream.openStreamingPlatformChannelId == nil {

--- a/Moblin/Various/Utils.swift
+++ b/Moblin/Various/Utils.swift
@@ -136,8 +136,12 @@ extension Data {
     }
 }
 
-func randomHumanString() -> String {
-    return Data.random(length: 10).base64EncodedString().replacingOccurrences(
+func randomString() -> String {
+    return Data.random(length: 64).base64EncodedString()
+}
+
+func randomHumanString(length: Int) -> String {
+    return Data.random(length: length).base64EncodedString().replacingOccurrences(
         of: "[+/=]",
         with: "",
         options: .regularExpression

--- a/Moblin/Various/Utils.swift
+++ b/Moblin/Various/Utils.swift
@@ -140,8 +140,8 @@ func randomString() -> String {
     return Data.random(length: 64).base64EncodedString()
 }
 
-func randomHumanString(length: Int) -> String {
-    return Data.random(length: length).base64EncodedString().replacingOccurrences(
+func randomHumanString() -> String {
+    return Data.random(length: 10).base64EncodedString().replacingOccurrences(
         of: "[+/=]",
         with: "",
         options: .regularExpression

--- a/Moblin/View/Settings/Streams/Stream/OpenStreamingPlatform/StreamOpenStreamingPlatformSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/OpenStreamingPlatform/StreamOpenStreamingPlatformSettingsView.swift
@@ -23,22 +23,6 @@ struct StreamOpenStreamingPlatformSettingsView: View {
         }
     }
 
-    func submitUsername(value: String) {
-        stream.openStreamingPlatformUsername = value
-        model.store()
-        if stream.enabled {
-            model.openStreamingPlatformUsernameUpdated()
-        }
-    }
-
-    func submitPassword(value: String) {
-        stream.openStreamingPlatformPassword = value
-        model.store()
-        if stream.enabled {
-            model.openStreamingPlatformPasswordUpdated()
-        }
-    }
-
     var body: some View {
         Form {
             Section {
@@ -53,17 +37,6 @@ struct StreamOpenStreamingPlatformSettingsView: View {
                     value: stream.openStreamingPlatformChannelId!,
                     onSubmit: submitRoom,
                     placeholder: "4e9f02fc-cee9-4d1c-b4b5-99b9496375c8"
-                )
-                TextEditNavigationView(
-                    title: String(localized: "Username"),
-                    value: stream.openStreamingPlatformUsername!,
-                    onSubmit: submitUsername
-                )
-                TextEditNavigationView(
-                    title: String(localized: "Password"),
-                    value: stream.openStreamingPlatformPassword!,
-                    onSubmit: submitPassword,
-                    sensitive: true
                 )
             }
         }


### PR DESCRIPTION
- static username
- generate password at runtime

(No user-specific setting is required for either parameter)

- reduce configuration view to relevant parameters
- refactor func randomString
- small fix for checking whether osp has been configured