### PR TITLE
RTMP Audio selectable in microphone settings

### DIFF
--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -1074,6 +1074,7 @@ enum SettingsMic: String, Codable, CaseIterable {
     case front = "Front"
     case back = "Back"
     case top = "Top"
+    case rtmp = "RTMP"
 
     public init(from decoder: Decoder) throws {
         self = try SettingsMic(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .bottom


### PR DESCRIPTION
- RTMP Audio selectable in microphone settings
- Audio no longer changes automatically when changing scenes

Advantage:
- mic selection that do not change with scene
- every audio (internal, external, rtmp) can now be used for every scene
- no more freezes when switching scenes

Disadvantage:
Internal camera + rtmp camera or internal audio + rtmp audio are not in sync

ToDo:
Save mic settings when selecting rtmp. Currently the botton mic is automatically selected when Moblin starts.