### PR TITLE
Auto stream and recording in OBS

### DIFF
--- a/Moblin/Various/Model.swift
+++ b/Moblin/Various/Model.swift
@@ -2525,6 +2525,12 @@ final class Model: NSObject, ObservableObject {
         if stream.recording!.autoStartRecording! {
             startRecording()
         }
+        if stream.obsAutoStartStream! {
+            obsStartStream()
+        }
+        if stream.obsAutoStartRecording! {
+            obsStartRecording()
+        }
         streamingHistoryStream = StreamingHistoryStream(settings: stream.clone())
         streamingHistoryStream!.updateHighestThermalState(thermalState: ThermalState(from: thermalState))
         streamingHistoryStream!.updateLowestBatteryLevel(level: batteryLevel)
@@ -2542,6 +2548,12 @@ final class Model: NSObject, ObservableObject {
         streaming = false
         if stream.recording!.autoStopRecording! {
             stopRecording()
+        }
+        if stream.obsAutoStopStream! {
+            obsStopStream()
+        }
+        if stream.obsAutoStopRecording! {
+            obsStopRecording()
         }
         stopNetStream()
         streamState = .disconnected

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -380,6 +380,10 @@ class SettingsStream: Codable, Identifiable, Equatable {
     var obsWebSocketPassword: String? = ""
     var obsSourceName: String? = ""
     var obsBrbScene: String? = ""
+    var obsAutoStartStream: Bool? = false
+    var obsAutoStopStream: Bool? = false
+    var obsAutoStartRecording: Bool? = false
+    var obsAutoStopRecording: Bool? = false
     var resolution: SettingsStreamResolution = .r1920x1080
     var fps: Int = 30
     var bitrate: UInt32 = 5_000_000
@@ -426,6 +430,11 @@ class SettingsStream: Codable, Identifiable, Equatable {
         new.obsWebSocketUrl = obsWebSocketUrl
         new.obsWebSocketPassword = obsWebSocketPassword
         new.obsSourceName = obsSourceName
+        new.obsBrbScene = obsBrbScene
+        new.obsAutoStartStream = obsAutoStartStream
+        new.obsAutoStopStream = obsAutoStopStream
+        new.obsAutoStartRecording = obsAutoStartRecording
+        new.obsAutoStopRecording = obsAutoStopRecording
         new.resolution = resolution
         new.fps = fps
         new.bitrate = bitrate
@@ -2872,6 +2881,22 @@ final class Settings {
         }
         for widget in realDatabase.widgets where widget.text.clearForegroundColor == nil {
             widget.text.clearForegroundColor = false
+            store()
+        }
+        for stream in realDatabase.streams where stream.obsAutoStartStream == nil {
+            stream.obsAutoStartStream = false
+            store()
+        }
+        for stream in realDatabase.streams where stream.obsAutoStopStream == nil {
+            stream.obsAutoStopStream = false
+            store()
+        }
+        for stream in realDatabase.streams where stream.obsAutoStartRecording == nil {
+            stream.obsAutoStartRecording = false
+            store()
+        }
+        for stream in realDatabase.streams where stream.obsAutoStopRecording == nil {
+            stream.obsAutoStopRecording = false
             store()
         }
     }

--- a/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
@@ -92,7 +92,7 @@ struct StreamObsRemoteControlSettingsView: View {
                 }))
             }
             footer: {
-                Text("OBS will automatically start or stop stream according to the Moblin stream status.")
+                Text("OBS will automatically start or stop stream according to the Moblin live status.")
             }
             Section {
                 Toggle("Auto start recording when going live", isOn: Binding(get: {
@@ -109,7 +109,7 @@ struct StreamObsRemoteControlSettingsView: View {
                 }))
             }
             footer: {
-                Text("OBS will automatically start or stop recording according to the Moblin stream status.")
+                Text("OBS will automatically start or stop recording according to the Moblin live status.")
             }
         }
         .navigationTitle("OBS remote control")

--- a/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
@@ -78,38 +78,32 @@ struct StreamObsRemoteControlSettingsView: View {
                 Text("The name of the Source in OBS that receives the stream from Moblin.")
             }
             Section {
-                Toggle("Auto start streaming when going live", isOn: Binding(get: {
-                    stream.obsAutoStartRecording!
-                }, set: { value in
-                    stream.obsAutoStartRecording = value
-                    model.store()
-                }))
-                Toggle("Auto stop streaming when ending stream", isOn: Binding(get: {
-                    stream.obsAutoStopRecording!
-                }, set: { value in
-                    stream.obsAutoStopRecording = value
-                    model.store()
-                }))
-            }
-            footer: {
-                Text("OBS will automatically start or stop stream according to the Moblin live status.")
-            }
-            Section {
-                Toggle("Auto start recording when going live", isOn: Binding(get: {
+                Toggle("Auto start stream when going live", isOn: Binding(get: {
                     stream.obsAutoStartStream!
                 }, set: { value in
                     stream.obsAutoStartStream = value
                     model.store()
                 }))
-                Toggle("Auto stop recording when ending stream", isOn: Binding(get: {
+                Toggle("Auto stop stream when ending stream", isOn: Binding(get: {
                     stream.obsAutoStopStream!
                 }, set: { value in
                     stream.obsAutoStopStream = value
                     model.store()
                 }))
             }
-            footer: {
-                Text("OBS will automatically start or stop recording according to the Moblin live status.")
+            Section {
+                Toggle("Auto start recording when going live", isOn: Binding(get: {
+                    stream.obsAutoStartRecording!
+                }, set: { value in
+                    stream.obsAutoStartRecording = value
+                    model.store()
+                }))
+                Toggle("Auto stop recording when ending stream", isOn: Binding(get: {
+                    stream.obsAutoStopRecording!
+                }, set: { value in
+                    stream.obsAutoStopRecording = value
+                    model.store()
+                }))
             }
         }
         .navigationTitle("OBS remote control")

--- a/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/ObsRemoteControl/StreamObsRemoteControlSettingsView.swift
@@ -77,6 +77,40 @@ struct StreamObsRemoteControlSettingsView: View {
             } footer: {
                 Text("The name of the Source in OBS that receives the stream from Moblin.")
             }
+            Section {
+                Toggle("Auto start streaming when going live", isOn: Binding(get: {
+                    stream.obsAutoStartRecording!
+                }, set: { value in
+                    stream.obsAutoStartRecording = value
+                    model.store()
+                }))
+                Toggle("Auto stop streaming when ending stream", isOn: Binding(get: {
+                    stream.obsAutoStopRecording!
+                }, set: { value in
+                    stream.obsAutoStopRecording = value
+                    model.store()
+                }))
+            }
+            footer: {
+                Text("OBS will automatically start or stop stream according to the Moblin stream status.")
+            }
+            Section {
+                Toggle("Auto start recording when going live", isOn: Binding(get: {
+                    stream.obsAutoStartStream!
+                }, set: { value in
+                    stream.obsAutoStartStream = value
+                    model.store()
+                }))
+                Toggle("Auto stop recording when ending stream", isOn: Binding(get: {
+                    stream.obsAutoStopStream!
+                }, set: { value in
+                    stream.obsAutoStopStream = value
+                    model.store()
+                }))
+            }
+            footer: {
+                Text("OBS will automatically start or stop recording according to the Moblin stream status.")
+            }
         }
         .navigationTitle("OBS remote control")
         .toolbar {


### PR DESCRIPTION
New OBS Remote settings to automatically start or stop stream/recording according to the Moblin live status.