### PR TITLE
Added preliminary support for DJI Osmo Action 5 Pro

### DIFF
--- a/Moblin/Integrations/DjiDevice/DjiDevice.swift
+++ b/Moblin/Integrations/DjiDevice/DjiDevice.swift
@@ -362,6 +362,18 @@ extension DjiDevice: CBPeripheralDelegate {
                                          id: startStreamingTransactionId,
                                          type: startStreamingType,
                                          payload: payload.encode()))
+        
+        // Patch for OA5P: Send the confirmation payload to actually start the stream.
+        // This is an exact copy of the stop-streaming command, but the last data-bit in the payload is set to 1 instead of 2.
+        // It may probably work fine sending it on all devices, but limiting it to OA5P for now.
+        if(model == .osmoAction5Pro){
+            let confirmStartStreamPayload = DjiConfirmStartStreamingMessagePayload()
+            writeMessage(message: DjiMessage(target: stopStreamingTarget,
+                                             id: stopStreamingTransactionId,
+                                             type: stopStreamingType,
+                                             payload: confirmStartStreamPayload.encode()))
+        }
+        
         setState(state: .startingStream)
     }
 

--- a/Moblin/Integrations/DjiDevice/DjiMessage.swift
+++ b/Moblin/Integrations/DjiDevice/DjiMessage.swift
@@ -200,6 +200,14 @@ class DjiStartStreamingMessagePayload {
     }
 }
 
+class DjiConfirmStartStreamingMessagePayload {
+    static let payload = Data([0x01, 0x01, 0x1A, 0x00, 0x01, 0x01])
+
+    func encode() -> Data {
+        return DjiConfirmStartStreamingMessagePayload.payload
+    }
+}
+
 class DjiStopStreamingMessagePayload {
     static let payload = Data([0x01, 0x01, 0x1A, 0x00, 0x01, 0x02])
 


### PR DESCRIPTION
This patch would enable the DJI Osmo Action 5 Pro to start stream, before the new DJI library is created.

Pairing may still be bit buggy. (May have to "start stream" twice the first time if the device havent been paired to the phone before)

