### PR TITLE
Add portrait as a quick button view

### DIFF
--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -1455,6 +1455,7 @@ enum SettingsButtonType: String, Codable, CaseIterable {
     case interactiveChat = "Interactive chat"
     case lockScreen = "Lock screen"
     case djiDevices = "DJI devices"
+    case portrait = "Portrait"
 
     public init(from decoder: Decoder) throws {
         var value = try decoder.singleValueContainer().decode(RawValue.self)
@@ -3028,12 +3029,23 @@ private func addMissingGlobalButtons(database: Database) {
     button.systemImageNameOn = "camera.rotate.fill"
     button.systemImageNameOff = "camera.rotate"
     updateGlobalButton(database: database, button: button)
-
+    
+    button = SettingsButton(name: String(localized: "Portrait"))
+    button.id = UUID()
+    button.type = .portrait
+    button.imageType = "System name"
+    button.systemImageNameOn = "rectangle.portrait.rotate"
+    button.systemImageNameOff = "rectangle.portrait.rotate"
+    updateGlobalButton(database: database, button: button)
+    
     database.globalButtons = database.globalButtons!.filter { button in
         if button.type == .unknown {
             return false
         }
         if button.type == .workout, !isPhone() {
+            return false
+        }
+        if button.type == .portrait, !isPhone() {
             return false
         }
         return true

--- a/Moblin/View/ControlBar/QuickButtonsView.swift
+++ b/Moblin/View/ControlBar/QuickButtonsView.swift
@@ -267,6 +267,11 @@ struct QuickButtonsInnerView: View {
         model.toggleShowingPanel(type: .djiDevices, panel: .djiDevices)
         model.updateLutsButtonState()
     }
+    
+    private func portraitAction(state _: ButtonState) {
+        model.database.portrait?.toggle()
+        model.updateOrientationLock()
+    }
 
     var body: some View {
         VStack {
@@ -543,6 +548,12 @@ struct QuickButtonsInnerView: View {
             case .djiDevices:
                 Button(action: {
                     djiDevicesAction(state: state)
+                }, label: {
+                    QuickButtonImage(state: state, buttonSize: size)
+                })
+            case .portrait:
+                Button(action: {
+                    portraitAction(state: state)
                 }, label: {
                     QuickButtonImage(state: state, buttonSize: size)
                 })


### PR DESCRIPTION
Use case: 

- Landscape when changing scene from a DJI device to the phone cam
- Portrait mode for “chat only”

<img src="https://github.com/user-attachments/assets/7da979f8-740a-4098-aa75-3a31fa4b1c4b" width="400">

