### PR TITLE
Added setting for apple watch to control massge notification rate.

### DIFF
--- a/Moblin Watch/Shared/WatchSettings.swift
+++ b/Moblin Watch/Shared/WatchSettings.swift
@@ -4,6 +4,7 @@ class WatchSettingsChat: Codable {
     var fontSize: Float = 17.0
     var timestampEnabled: Bool? = true
     var notificationOnMessage: Bool? = false
+    var notificationRate: Int? = 30
     var badges: Bool? = true
 }
 

--- a/Moblin Watch/Various/Model.swift
+++ b/Moblin Watch/Various/Model.swift
@@ -221,7 +221,7 @@ class Model: NSObject, ObservableObject {
         }
         nextExpectedWatchChatPostId = message.id + 1
         let now = ContinuousClock.now
-        if latestChatMessageTime + .seconds(30) < now {
+        if latestChatMessageTime + .seconds(settings.chat.notificationRate ?? 1) < now {
             appendRedLineMessage(message: message)
             if settings.chat.notificationOnMessage! {
                 WKInterfaceDevice.current().play(.notification)
@@ -308,6 +308,10 @@ class Model: NSObject, ObservableObject {
         if self.settings.show == nil {
             self.settings.show = .init()
         }
+        if self.settings.chat.notificationRate == nil {
+            self.settings.chat.notificationRate = 1
+        }
+        
         viaRemoteControl = self.settings.viaRemoteControl ?? false
     }
 

--- a/Moblin/View/Settings/Watch/Chat/WatchChatSettingsView.swift
+++ b/Moblin/View/Settings/Watch/Chat/WatchChatSettingsView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct WatchChatSettingsView: View {
     @EnvironmentObject var model: Model
     @State var fontSize: Float
-
+    @State var notificationRate: Int
+    
     var body: some View {
         Form {
             Section {
@@ -51,6 +52,19 @@ struct WatchChatSettingsView: View {
                 })) {
                     Text("Notification on message")
                 }
+                HStack {
+                    Text("Notification rate")
+                    Spacer()
+                    TextField("", value: $notificationRate, formatter: NumberFormatter())
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 60)
+                        .onChange(of: notificationRate) { newValue in
+                            model.database.watch.chat.notificationRate = Int(newValue)
+                            model.sendSettingsToWatch()
+                        }
+                }
+
             } header: {
                 Text("General")
             }

--- a/Moblin/View/Settings/Watch/WatchSettingsView.swift
+++ b/Moblin/View/Settings/Watch/WatchSettingsView.swift
@@ -7,7 +7,7 @@ struct WatchSettingsView: View {
         Form {
             Section {
                 NavigationLink {
-                    WatchChatSettingsView(fontSize: model.database.watch.chat.fontSize)
+                    WatchChatSettingsView(fontSize: model.database.watch.chat.fontSize, notificationRate: model.database.watch.chat.notificationRate ?? 1)
                 } label: {
                     Text("Chat")
                 }


### PR DESCRIPTION
This gives option for streamer to set fetch rate to 1 seccond that triggers notification on every message received there for giving more interaction abilities for smaller streamers where big channels can set it to 30+ secconds to have notifications as is.