### PR TITLE
Fixed issues with Black Shark phone cooler integration

### DIFF
--- a/Common/Various/CommonUtils.swift
+++ b/Common/Various/CommonUtils.swift
@@ -735,6 +735,19 @@ extension Color {
             opacity: components.count == 4 ? components[3] : 1.0
         )
     }
+
+    /// Returns an RgbColor within the standard range. meaning the value is clamped to be in between 0 and 255
+    func toStandardRgb() -> RgbColor? {
+        guard let extendedRgbColor = toRgb() else {
+            return nil
+        }
+        return RgbColor(
+            red: min(max(extendedRgbColor.red, 0), 255),
+            green: min(max(extendedRgbColor.green, 0), 255),
+            blue: min(max(extendedRgbColor.blue, 0), 255),
+            opacity: extendedRgbColor.opacity
+        )
+    }
 }
 
 func isSetWin(first: Int, second: Int) -> Bool {

--- a/Moblin/Integrations/PhoneCooler/PhoneCoolerDevice.swift
+++ b/Moblin/Integrations/PhoneCooler/PhoneCoolerDevice.swift
@@ -199,26 +199,22 @@ extension PhoneCoolerDevice: CBPeripheralDelegate {
             fanSpeedTarget = 100
             logger.warning("phone-cooler-device: Thermal state is unknown value")
         }
-        let newCoolingPower = updatedPercentageScale(coolingPower, target: coolingPowerTarget)
-        if newCoolingPower != coolingPower {
-            coolingPower = newCoolingPower
-            logger.debug("phone-cooler-device: Adjusting cooling power to \(newCoolingPower) %")
-            peripheral.writeValue(
-                BlackSharkLib.getSetFanSpeedCommand(newCoolingPower)!,
-                for: writeCharacteristic,
-                type: .withoutResponse
-            )
-        }
-        let newFanSpeed = updatedPercentageScale(fanSpeed, target: fanSpeedTarget)
-        if newFanSpeed != fanSpeed {
-            fanSpeed = newFanSpeed
-            logger.debug("phone-cooler-device: Adjusting fan speed to \(newFanSpeed) %")
-            peripheral.writeValue(
-                BlackSharkLib.getSetCoolingPowerCommand(newFanSpeed)!,
-                for: writeCharacteristic,
-                type: .withoutResponse
-            )
-        }
+        // Since we do not know the fan and cooler-state we have to assume that it can be out of sync. sending the
+        // commands to update the cooling power and fan speed on every interval will make sure that its in sync.
+        let coolingPower = updatedPercentageScale(coolingPower, target: coolingPowerTarget)
+        logger.debug("phone-cooler-device: Adjusting cooling power to \(coolingPower) %")
+        peripheral.writeValue(
+            BlackSharkLib.getSetCoolingPowerCommand(coolingPower)!,
+            for: writeCharacteristic,
+            type: .withoutResponse
+        )
+        let fanSpeed = updatedPercentageScale(fanSpeed, target: fanSpeedTarget)
+        logger.debug("phone-cooler-device: Adjusting fan speed to \(fanSpeed) %")
+        peripheral.writeValue(
+            BlackSharkLib.getSetFanSpeedCommand(fanSpeed)!,
+            for: writeCharacteristic,
+            type: .withoutResponse
+        )
     }
 
     func setLedColor(color: RgbColor, brightness: Int) {

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -4100,7 +4100,7 @@ class SettingsPhoneCoolerDevice: Codable, Identifiable, ObservableObject {
     @Published var ledLightsIsEnabled: Bool = false
     var rgbLightColor: RgbColor = defaultRgbLightColor
     @Published var rgbLightColorColor: Color = defaultRgbLightColor.color()
-    @Published var rgbLightBrightness: Double = 1.0
+    @Published var rgbLightBrightness: Double = 100.0
 
     enum CodingKeys: CodingKey {
         case id,

--- a/Moblin/View/Settings/PhoneCoolers/PhoneCoolerDeviceSettingsView.swift
+++ b/Moblin/View/Settings/PhoneCoolers/PhoneCoolerDeviceSettingsView.swift
@@ -131,7 +131,7 @@ struct PhoneCoolerDeviceSettingsView: View {
                     if device.ledLightsIsEnabled {
                         ColorPicker("Color", selection: $device.rgbLightColorColor, supportsOpacity: false)
                             .onChange(of: device.rgbLightColorColor) { _ in
-                                guard let color = device.rgbLightColorColor.toRgb() else {
+                                guard let color = device.rgbLightColorColor.toStandardRgb() else {
                                     return
                                 }
                                 device.rgbLightColor = color


### PR DESCRIPTION
**Fixed Brightness and LED issues**
- Brightness was set to default as 1 out of a 0-100 range. So set it 100 for full brightness. users can adjust it after.
- Created new extension function toStandardRGB which supplements the color and toRgbp value. It seems like apples "Standard" RGB is actually extended RGB where the value range can go above 1 and below 0, which breaks stuff. The toStandardRgB clamps this to prevent issues further down with integer conversions. The new function is used for the LED settings. Main reason for a new function was to not break other parts of the code that uses toRgb() which may relie on that extended RGB.

**Fixed some issues with setting cooling power and fan speed**
The values for cooling power and fan speed was switched up.  I also removed a check for the local value was the same as the one that is calculated, since that would make it only update if the phone knows it should update. Since the fan can be controlled by a button or reset with a power cycle, we have to assume that it can get out of sync, so sending the bluetooth commands on every interval would make sure it gets back into sync.