### PR TITLE
settings toggle to show or hide deleted chat messages

### DIFF
--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -3071,6 +3071,7 @@ class SettingsChat: Codable, ObservableObject {
     @Published var newMessagesAtTop: Bool = false
     @Published var textToSpeechPauseBetweenMessages: Double = 1.0
     @Published var platform: Bool = true
+    @Published var showDeletedMessages: Bool = false
 
     enum CodingKeys: CodingKey {
         case fontSize,
@@ -3112,7 +3113,8 @@ class SettingsChat: Codable, ObservableObject {
              bottomPoints,
              newMessagesAtTop,
              textToSpeechPauseBetweenMessages,
-             platform
+             platform,
+             showDeletedMessages
     }
 
     func encode(to encoder: Encoder) throws {
@@ -3157,6 +3159,7 @@ class SettingsChat: Codable, ObservableObject {
         try container.encode(.newMessagesAtTop, newMessagesAtTop)
         try container.encode(.textToSpeechPauseBetweenMessages, textToSpeechPauseBetweenMessages)
         try container.encode(.platform, platform)
+        try container.encode(.showDeletedMessages, showDeletedMessages)
     }
 
     init() {}
@@ -3211,6 +3214,7 @@ class SettingsChat: Codable, ObservableObject {
         newMessagesAtTop = container.decode(.newMessagesAtTop, Bool.self, false)
         textToSpeechPauseBetweenMessages = container.decode(.textToSpeechPauseBetweenMessages, Double.self, 1.0)
         platform = container.decode(.platform, Bool.self, true)
+        showDeletedMessages = container.decode(.showDeletedMessages, Bool.self, false)
     }
 
     func getRotation() -> Double {
@@ -6630,6 +6634,10 @@ final class Settings {
         }
         if realDatabase.chat.botCommandPermissions.stream == nil {
             realDatabase.chat.botCommandPermissions.stream = .init()
+            store()
+        }
+        if realDatabase.chat.showDeletedMessages == nil {
+            realDatabase.chat.showDeletedMessages = false
             store()
         }
     }

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonChatView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonChatView.swift
@@ -23,6 +23,7 @@ private struct HighlightMessageView: View {
 }
 
 private struct LineView: View {
+    @ObservedObject var data: ObservablePostData
     var post: ChatPost
     @ObservedObject var chat: SettingsChat
     var platform: Bool
@@ -73,6 +74,8 @@ private struct LineView: View {
             ForEach(post.segments, id: \.id) { segment in
                 if let text = segment.text {
                     Text(text)
+                        .foregroundColor(data.deleted ? .gray : .white)
+                        .strikethrough(data.deleted)
                         .italic(post.isAction)
                 }
                 if let url = segment.url {
@@ -124,32 +127,36 @@ private struct MessagesView: View {
                         .frame(height: 1)
                     ForEach(chat.posts) { post in
                         if post.user != nil {
-                            if let highlight = post.highlight {
-                                HStack(spacing: 0) {
-                                    Rectangle()
-                                        .frame(width: 3)
-                                        .foregroundColor(highlight.barColor)
-                                    VStack(alignment: .leading, spacing: 1) {
-                                        HighlightMessageView(
-                                            image: highlight.image,
-                                            name: highlight.title
-                                        )
-                                        LineView(post: post,
-                                                 chat: chatSettings,
-                                                 platform: chat.moreThanOneStreamingPlatform,
-                                                 selectedPost: $selectedPost)
+                            if post.data.deleted == false || chatSettings.showDeletedMessages {
+                                if let highlight = post.highlight {
+                                    HStack(spacing: 0) {
+                                        Rectangle()
+                                            .frame(width: 3)
+                                            .foregroundColor(highlight.barColor)
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            HighlightMessageView(
+                                                image: highlight.image,
+                                                name: highlight.title
+                                            )
+                                            LineView(data: post.data,
+                                                     post: post,
+                                                     chat: chatSettings,
+                                                     platform: chat.moreThanOneStreamingPlatform,
+                                                     selectedPost: $selectedPost)
+                                        }
                                     }
-                                }
-                                .rotationEffect(Angle(degrees: rotation))
-                                .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
-                            } else {
-                                LineView(post: post,
-                                         chat: chatSettings,
-                                         platform: chat.moreThanOneStreamingPlatform,
-                                         selectedPost: $selectedPost)
+                                    .rotationEffect(Angle(degrees: rotation))
+                                    .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                } else {
+                                    LineView(data: post.data,
+                                             post: post,
+                                             chat: chatSettings,
+                                             platform: chat.moreThanOneStreamingPlatform,
+                                             selectedPost: $selectedPost)
                                     .padding([.leading], 3)
                                     .rotationEffect(Angle(degrees: rotation))
                                     .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                }
                             }
                         } else {
                             Rectangle()
@@ -300,7 +307,8 @@ private struct AlertsMessagesView: View {
                                                 image: highlight.image,
                                                 name: highlight.title
                                             )
-                                            LineView(post: post,
+                                            LineView(data: post.data,
+                                                     post: post,
                                                      chat: chatSettings,
                                                      platform: chat.moreThanOneStreamingPlatform,
                                                      selectedPost: $selectedPost)
@@ -310,7 +318,8 @@ private struct AlertsMessagesView: View {
                                     .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
                                 }
                             } else {
-                                LineView(post: post,
+                                LineView(data: post.data,
+                                         post: post,
                                          chat: chatSettings,
                                          platform: chat.moreThanOneStreamingPlatform,
                                          selectedPost: $selectedPost)
@@ -516,7 +525,8 @@ private struct ActionButtonsView: View {
                     }
                 VStack(alignment: .leading) {
                     ScrollView {
-                        LineView(post: selectedPost,
+                        LineView(data: selectedPost.data,
+                                 post: selectedPost,
                                  chat: model.database.chat,
                                  platform: model.chat.moreThanOneStreamingPlatform,
                                  selectedPost: $selectedPost)

--- a/Moblin/View/ExternalDisplay/ExternalDisplayView.swift
+++ b/Moblin/View/ExternalDisplay/ExternalDisplayView.swift
@@ -28,6 +28,7 @@ private struct HighlightMessageView: View {
 }
 
 private struct LineView: View {
+    @ObservedObject var data: ObservablePostData
     var post: ChatPost
     @ObservedObject var chat: SettingsChat
     var platform: Bool
@@ -81,7 +82,10 @@ private struct LineView: View {
             ForEach(post.segments, id: \.id) { segment in
                 if let text = segment.text {
                     Text(text)
+                        .foregroundColor(data.deleted ? .gray : .white)
+                        .strikethrough(data.deleted)
                         .italic(post.isAction)
+                        
                 }
                 if let url = segment.url {
                     if chat.animatedEmotes {
@@ -122,31 +126,35 @@ private struct MessagesView: View {
                     LazyVStack(alignment: .leading, spacing: 1) {
                         ForEach(chat.posts) { post in
                             if post.user != nil {
-                                if let highlight = post.highlight {
-                                    HStack(spacing: 0) {
-                                        Rectangle()
-                                            .frame(width: 3)
-                                            .foregroundColor(highlight.barColor)
-                                        VStack(alignment: .leading, spacing: 1) {
-                                            HighlightMessageView(
-                                                chat: chatSettings,
-                                                image: highlight.image,
-                                                name: highlight.title
-                                            )
-                                            LineView(post: post,
-                                                     chat: chatSettings,
-                                                     platform: chat.moreThanOneStreamingPlatform)
+                                if post.data.deleted == false || chatSettings.showDeletedMessages {
+                                    if let highlight = post.highlight {
+                                        HStack(spacing: 0) {
+                                            Rectangle()
+                                                .frame(width: 3)
+                                                .foregroundColor(highlight.barColor)
+                                            VStack(alignment: .leading, spacing: 1) {
+                                                HighlightMessageView(
+                                                    chat: chatSettings,
+                                                    image: highlight.image,
+                                                    name: highlight.title
+                                                )
+                                                LineView(data: post.data,
+                                                         post: post,
+                                                         chat: chatSettings,
+                                                         platform: chat.moreThanOneStreamingPlatform)
+                                            }
                                         }
-                                    }
-                                    .rotationEffect(Angle(degrees: rotation))
-                                    .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
-                                } else {
-                                    LineView(post: post,
-                                             chat: chatSettings,
-                                             platform: chat.moreThanOneStreamingPlatform)
+                                        .rotationEffect(Angle(degrees: rotation))
+                                        .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                    } else {
+                                        LineView(data: post.data,
+                                                 post: post,
+                                                 chat: chatSettings,
+                                                 platform: chat.moreThanOneStreamingPlatform)
                                         .padding([.leading], 3)
                                         .rotationEffect(Angle(degrees: rotation))
                                         .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                    }
                                 }
                             } else {
                                 Rectangle()

--- a/Moblin/View/Settings/Chat/ChatSettingsView.swift
+++ b/Moblin/View/Settings/Chat/ChatSettingsView.swift
@@ -59,6 +59,10 @@ struct ChatSettingsView: View {
                     Text(String(Int(chat.fontSize)))
                         .frame(width: 25)
                 }
+                Toggle("Show deleted messages", isOn: $chat.showDeletedMessages)
+                    .onChange(of: chat.showDeletedMessages) { _ in
+                        model.reloadChatMessages()
+                    }
                 if model.database.showAllSettings {
                     Toggle("Timestamp", isOn: $chat.timestampColorEnabled)
                         .onChange(of: chat.timestampColorEnabled) { _ in

--- a/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
+++ b/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
@@ -54,6 +54,7 @@ private struct HighlightMessageView: View {
 }
 
 private struct LineView: View {
+    @ObservedObject var data: ObservablePostData
     var post: ChatPost
     @ObservedObject var chat: SettingsChat
     var platform: Bool
@@ -142,7 +143,8 @@ private struct LineView: View {
             ForEach(post.segments, id: \.id) { segment in
                 if let text = segment.text {
                     Text(text)
-                        .foregroundColor(messageColor)
+                        .foregroundColor(data.deleted ? .gray : messageColor)
+                        .strikethrough(data.deleted)
                         .bold(chat.boldMessage)
                         .italic(post.isAction)
                 }
@@ -241,31 +243,35 @@ struct StreamOverlayChatView: View {
                                 .id(startId)
                             ForEach(chat.posts) { post in
                                 if post.user != nil {
-                                    if let highlight = post.highlight {
-                                        HStack(spacing: 0) {
-                                            Rectangle()
-                                                .frame(width: 3)
-                                                .foregroundColor(highlight.barColor)
-                                            VStack(alignment: .leading, spacing: 1) {
-                                                HighlightMessageView(
-                                                    chat: chatSettings,
-                                                    image: highlight.image,
-                                                    name: highlight.title
-                                                )
-                                                LineView(post: post,
-                                                         chat: chatSettings,
-                                                         platform: chat.moreThanOneStreamingPlatform)
+                                    if post.data.deleted == false || chatSettings.showDeletedMessages {
+                                        if let highlight = post.highlight {
+                                            HStack(spacing: 0) {
+                                                Rectangle()
+                                                    .frame(width: 3)
+                                                    .foregroundColor(highlight.barColor)
+                                                VStack(alignment: .leading, spacing: 1) {
+                                                    HighlightMessageView(
+                                                        chat: chatSettings,
+                                                        image: highlight.image,
+                                                        name: highlight.title
+                                                    )
+                                                    LineView(data: post.data,
+                                                             post: post,
+                                                             chat: chatSettings,
+                                                             platform: chat.moreThanOneStreamingPlatform)
+                                                }
                                             }
-                                        }
-                                        .rotationEffect(Angle(degrees: rotation))
-                                        .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
-                                    } else {
-                                        LineView(post: post,
-                                                 chat: chatSettings,
-                                                 platform: chat.moreThanOneStreamingPlatform)
+                                            .rotationEffect(Angle(degrees: rotation))
+                                            .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                        } else {
+                                            LineView(data: post.data,
+                                                     post: post,
+                                                     chat: chatSettings,
+                                                     platform: chat.moreThanOneStreamingPlatform)
                                             .padding([.leading], 3)
                                             .rotationEffect(Angle(degrees: rotation))
                                             .scaleEffect(x: scaleX, y: 1.0, anchor: .center)
+                                        }
                                     }
                                 } else {
                                     Rectangle()


### PR DESCRIPTION
added a toggle in settings -> chat to let the user show deleted chat messages in ChatOverlay, QuickButtonChat and ExternalScreen. Deleted messages will be greyed out and have a strikethrough. Default setting is, that deleted messages will be completely hidden.