### PR TITLE
move IPv6 URLs to subpages for SRT(LA) Server, RTMP Server and Moblin…

### DIFF
--- a/Moblin/View/Settings/Moblink/MoblinkSettingsView.swift
+++ b/Moblin/View/Settings/Moblink/MoblinkSettingsView.swift
@@ -259,7 +259,7 @@ private struct StreamerView: View {
     }
 }
 
-private struct UrlsView: View {
+private struct UrlsViewIPv6: View {
     @EnvironmentObject var model: Model
     @ObservedObject var status: StatusOther
 
@@ -267,18 +267,6 @@ private struct UrlsView: View {
         NavigationLink {
             Form {
                 List {
-                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
-                        InterfaceView(
-                            ip: status.ipType.formatAddress(status.ip),
-                            port: model.database.moblink.server.port,
-                            image: urlImage(interfaceType: status.interfaceType)
-                        )
-                    }
-                    InterfaceView(
-                        ip: personalHotspotLocalAddress,
-                        port: model.database.moblink.server.port,
-                        image: "personalhotspot"
-                    )
                     ForEach(status.ipStatuses.filter { $0.ipType == .ipv6 }) { status in
                         InterfaceView(
                             ip: status.ipType.formatAddress(status.ip),
@@ -286,6 +274,40 @@ private struct UrlsView: View {
                             image: urlImage(interfaceType: status.interfaceType)
                         )
                     }
+                }
+            }
+            .navigationTitle("IPv6 URLs")
+        } label: {
+            Text("IPv6 URLs")
+        }
+    }
+}
+
+private struct UrlsView: View {
+    @EnvironmentObject var model: Model
+    @ObservedObject var status: StatusOther
+
+    var body: some View {
+        NavigationLink {
+            Form {
+                Section {
+                    List {
+                        ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
+                            InterfaceView(
+                                ip: status.ipType.formatAddress(status.ip),
+                                port: model.database.moblink.server.port,
+                                image: urlImage(interfaceType: status.interfaceType)
+                            )
+                        }
+                        InterfaceView(
+                            ip: personalHotspotLocalAddress,
+                            port: model.database.moblink.server.port,
+                            image: "personalhotspot"
+                        )
+                    }
+                }
+                Section {
+                    UrlsViewIPv6(status: status)
                 }
             }
             .navigationTitle("URLs")

--- a/Moblin/View/Settings/RtmpServer/RtmpServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/RtmpServer/RtmpServerStreamSettingsView.swift
@@ -36,6 +36,36 @@ private struct InterfaceView: View {
     }
 }
 
+private struct ProtocolUrlsViewIPv6: View {
+    @ObservedObject var status: StatusOther
+    let port: UInt16
+    let streamKey: String
+
+    private func title() -> String {
+        return "IPv6 URLs"
+    }
+
+    var body: some View {
+        NavigationLink {
+            Form {
+                List {
+                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv6 }) { status in
+                        InterfaceView(
+                            port: port,
+                            streamKey: streamKey,
+                            image: urlImage(interfaceType: status.interfaceType),
+                            ip: status.ipType.formatAddress(status.ip)
+                        )
+                    }
+                }
+            }
+            .navigationTitle(title())
+        } label: {
+            Text(title())
+        }
+    }
+}
+
 private struct ProtocolUrlsView: View {
     @ObservedObject var status: StatusOther
     let port: UInt16
@@ -48,29 +78,26 @@ private struct ProtocolUrlsView: View {
     var body: some View {
         NavigationLink {
             Form {
-                List {
-                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
+                Section {
+                    List {
+                        ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
+                            InterfaceView(
+                                port: port,
+                                streamKey: streamKey,
+                                image: urlImage(interfaceType: status.interfaceType),
+                                ip: status.ipType.formatAddress(status.ip)
+                            )
+                        }
                         InterfaceView(
                             port: port,
                             streamKey: streamKey,
-                            image: urlImage(interfaceType: status.interfaceType),
-                            ip: status.ipType.formatAddress(status.ip)
+                            image: "personalhotspot",
+                            ip: personalHotspotLocalAddress
                         )
                     }
-                    InterfaceView(
-                        port: port,
-                        streamKey: streamKey,
-                        image: "personalhotspot",
-                        ip: personalHotspotLocalAddress
-                    )
-                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv6 }) { status in
-                        InterfaceView(
-                            port: port,
-                            streamKey: streamKey,
-                            image: urlImage(interfaceType: status.interfaceType),
-                            ip: status.ipType.formatAddress(status.ip)
-                        )
-                    }
+                }
+                Section {
+                    ProtocolUrlsViewIPv6(status: status, port: port, streamKey: streamKey)
                 }
             }
             .navigationTitle(title())

--- a/Moblin/View/Settings/SrtlaServer/SrtlaServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/SrtlaServer/SrtlaServerStreamSettingsView.swift
@@ -9,6 +9,38 @@ private func makeStreamUrl(proto: String, address: String, port: UInt16, streamI
     return url
 }
 
+private struct ProtocolUrlsViewIPv6: View {
+    @ObservedObject var status: StatusOther
+    let proto: String
+    let port: UInt16
+    let streamId: String
+
+    private func title() -> String {
+        return "\(proto.uppercased()) IPv6 URLs"
+    }
+
+    var body: some View {
+        NavigationLink {
+            Form {
+                List {
+                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv6 }) { status in
+                        InterfaceView(
+                            proto: proto,
+                            ip: status.ipType.formatAddress(status.ip),
+                            port: port,
+                            streamId: streamId,
+                            image: urlImage(interfaceType: status.interfaceType)
+                        )
+                    }
+                }
+            }
+            .navigationTitle(title())
+        } label: {
+            Text(title())
+        }
+    }
+}
+
 private struct ProtocolUrlsView: View {
     @ObservedObject var status: StatusOther
     let proto: String
@@ -22,32 +54,28 @@ private struct ProtocolUrlsView: View {
     var body: some View {
         NavigationLink {
             Form {
-                List {
-                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
+                Section {
+                    List {
+                        ForEach(status.ipStatuses.filter { $0.ipType == .ipv4 }) { status in
+                            InterfaceView(
+                                proto: proto,
+                                ip: status.ipType.formatAddress(status.ip),
+                                port: port,
+                                streamId: streamId,
+                                image: urlImage(interfaceType: status.interfaceType)
+                            )
+                        }
                         InterfaceView(
                             proto: proto,
-                            ip: status.ipType.formatAddress(status.ip),
+                            ip: personalHotspotLocalAddress,
                             port: port,
                             streamId: streamId,
-                            image: urlImage(interfaceType: status.interfaceType)
+                            image: "personalhotspot"
                         )
                     }
-                    InterfaceView(
-                        proto: proto,
-                        ip: personalHotspotLocalAddress,
-                        port: port,
-                        streamId: streamId,
-                        image: "personalhotspot"
-                    )
-                    ForEach(status.ipStatuses.filter { $0.ipType == .ipv6 }) { status in
-                        InterfaceView(
-                            proto: proto,
-                            ip: status.ipType.formatAddress(status.ip),
-                            port: port,
-                            streamId: streamId,
-                            image: urlImage(interfaceType: status.interfaceType)
-                        )
-                    }
+                }
+                Section {
+                    ProtocolUrlsViewIPv6(status: status, proto: proto, port: port, streamId: streamId)
                 }
             }
             .navigationTitle(title())


### PR DESCRIPTION
Most users wont need the IPv6 URLs, and they look very confusing for most people, also the list is very long when it includes the IPv6 addresses. Moved all IPv6 addresses to subpages for advanced users who know what they are doing, and make the UI cleaner this way for most of the normal users.