### PR TITLE
switch to defined audio source when switching scene

### DIFF
--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -385,6 +385,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     @Published var lockScreen = false
     @Published var findFace = false
     @Published var currentMic = noMic
+    @Published var previousMic = noMic
     @Published var mics: [Mic] = []
     @Published var isLive = false
     @Published var isRecording = false

--- a/Moblin/Various/Model/ModelAudio.swift
+++ b/Moblin/Various/Model/ModelAudio.swift
@@ -297,29 +297,29 @@ extension Model {
         }
     }
 
-    func manualSelectMicById(id: String) {
+    private func micExistsById(id: String) -> Mic? {
         guard let mic = mics.first(where: { mic in mic.id == id }) else {
             logger.info("Mic with id \(id) not found")
             makeErrorToast(
                 title: String(localized: "Mic not found"),
                 subTitle: String(localized: "Mic id \(id)")
             )
-            return
+            return nil
         }
-        selectMic(mic: mic)
-        previousMic = mic
+        return mic
+    }
+
+    func manualSelectMicById(id: String) {
+        if let mic = micExistsById(id: id) {
+            selectMic(mic: mic)
+            previousMic = mic
+        }
     }
 
     func selectMicById(id: String) {
-        guard let mic = mics.first(where: { mic in mic.id == id }) else {
-            logger.info("Mic with id \(id) not found")
-            makeErrorToast(
-                title: String(localized: "Mic not found"),
-                subTitle: String(localized: "Mic id \(id)")
-            )
-            return
+        if let mic = micExistsById(id: id) {
+            selectMic(mic: mic)
         }
-        selectMic(mic: mic)
     }
 
     private func selectMic(mic: Mic) {

--- a/Moblin/Various/Model/ModelAudio.swift
+++ b/Moblin/Various/Model/ModelAudio.swift
@@ -320,6 +320,7 @@ extension Model {
             selectMicDefault(mic: mic)
         }
     }
+    
 
     private func isRtmpMic(mic: Mic) -> Bool {
         guard let id = UUID(uuidString: mic.inputUid) else {
@@ -361,6 +362,14 @@ extension Model {
         let cameraId = getMediaPlayer(camera: mic.name)?.id ?? .init()
         media.attachBufferedAudio(cameraId: cameraId)
         remoteControlStreamer?.stateChanged(state: RemoteControlState(mic: mic.id))
+    }
+    
+    func getMicById(id: String) -> Mic? {
+        return mics.first(where: { mic in mic.id == id })
+    }
+    
+    func isMicAvailableById(id: String) -> Bool {
+        return mics.contains(where: { $0.id == id })
     }
 
     private func selectMicDefault(mic: Mic) {

--- a/Moblin/Various/Model/ModelAudio.swift
+++ b/Moblin/Various/Model/ModelAudio.swift
@@ -320,7 +320,6 @@ extension Model {
             selectMicDefault(mic: mic)
         }
     }
-    
 
     private func isRtmpMic(mic: Mic) -> Bool {
         guard let id = UUID(uuidString: mic.inputUid) else {
@@ -363,11 +362,11 @@ extension Model {
         media.attachBufferedAudio(cameraId: cameraId)
         remoteControlStreamer?.stateChanged(state: RemoteControlState(mic: mic.id))
     }
-    
+
     func getMicById(id: String) -> Mic? {
         return mics.first(where: { mic in mic.id == id })
     }
-    
+
     func isMicAvailableById(id: String) -> Bool {
         return mics.contains(where: { $0.id == id })
     }

--- a/Moblin/Various/Model/ModelAudio.swift
+++ b/Moblin/Various/Model/ModelAudio.swift
@@ -297,6 +297,19 @@ extension Model {
         }
     }
 
+    func manualSelectMicById(id: String) {
+        guard let mic = mics.first(where: { mic in mic.id == id }) else {
+            logger.info("Mic with id \(id) not found")
+            makeErrorToast(
+                title: String(localized: "Mic not found"),
+                subTitle: String(localized: "Mic id \(id)")
+            )
+            return
+        }
+        selectMic(mic: mic)
+        previousMic = mic
+    }
+
     func selectMicById(id: String) {
         guard let mic = mics.first(where: { mic in mic.id == id }) else {
             logger.info("Mic with id \(id) not found")
@@ -364,7 +377,7 @@ extension Model {
     }
 
     func getMicById(id: String) -> Mic? {
-        return mics.first(where: { mic in mic.id == id })
+        return mics.first(where: { $0.id == id })
     }
 
     func isMicAvailableById(id: String) -> Bool {

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -367,6 +367,11 @@ extension Model {
             sceneSelector.sceneIndex = index
             setSceneId(id: id)
             sceneUpdated(attachCamera: true, updateRemoteScene: false)
+            if let scene = enabledScenes.first(where: { $0.id == id }) {
+                if scene.micSwitch, mics.contains(where: { $0.id == scene.micId }), currentMic.id != scene.micId {
+                    selectMicById(id: scene.micId)
+                }
+            }
         }
     }
 

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -364,18 +364,30 @@ extension Model {
         if let index = enabledScenes.firstIndex(where: { scene in
             scene.id == id
         }) {
+            if let currentScene = getSelectedScene(),
+               !currentScene.overrideMic
+            {
+                previousMic = currentMic
+            }
             sceneSelector.sceneIndex = index
             setSceneId(id: id)
             sceneUpdated(attachCamera: true, updateRemoteScene: false)
-            if let scene = findEnabledScene(id: id),
-               scene.micOverride,
-               isMicAvailableById(id: scene.micId)
-            {
-                if currentMic.id != scene.micId {
-                    selectMicById(id: scene.micId)
+            if database.debug.sceneOverrideMic {
+                if let scene = findEnabledScene(id: id) {
+                    if scene.overrideMic {
+                        if currentMic.id != scene.micId {
+                            selectMicById(id: scene.micId)
+                        }
+                    } else {
+                        if currentMic.id != previousMic.id {
+                            if isMicAvailableById(id: previousMic.id) {
+                                selectMicById(id: previousMic.id)
+                            } else {
+                                setMicFromSettings()
+                            }
+                        }
+                    }
                 }
-            } else {
-                setMicFromSettings()
             }
         }
     }

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -369,7 +369,8 @@ extension Model {
             sceneUpdated(attachCamera: true, updateRemoteScene: false)
             if let scene = findEnabledScene(id: id),
                scene.micOverride,
-               isMicAvailableById(id: scene.micId) {
+               isMicAvailableById(id: scene.micId)
+            {
                 if currentMic.id != scene.micId {
                     selectMicById(id: scene.micId)
                 }

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -367,10 +367,14 @@ extension Model {
             sceneSelector.sceneIndex = index
             setSceneId(id: id)
             sceneUpdated(attachCamera: true, updateRemoteScene: false)
-            if let scene = enabledScenes.first(where: { $0.id == id }) {
-                if scene.micSwitch, mics.contains(where: { $0.id == scene.micId }), currentMic.id != scene.micId {
+            if let scene = findEnabledScene(id: id),
+               scene.micOverride,
+               isMicAvailableById(id: scene.micId) {
+                if currentMic.id != scene.micId {
                     selectMicById(id: scene.micId)
                 }
+            } else {
+                setMicFromSettings()
             }
         }
     }

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -896,7 +896,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
     @Published var videoStabilizationMode: SettingsVideoStabilizationMode = .off
     @Published var overrideVideoStabilizationMode: Bool = false
     @Published var fillFrame: Bool = false
-    @Published var micOverride: Bool = false
+    @Published var overrideMic: Bool = false
     @Published var micId: String = ""
 
     init(name: String) {
@@ -948,7 +948,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         try container.encode(.videoStabilizationMode, videoStabilizationMode)
         try container.encode(.overrideVideoStabilizationMode, overrideVideoStabilizationMode)
         try container.encode(.fillFrame, fillFrame)
-        try container.encode(.micSwitch, micOverride)
+        try container.encode(.micSwitch, overrideMic)
         try container.encode(.micId, micId)
     }
 
@@ -971,7 +971,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         videoStabilizationMode = container.decode(.videoStabilizationMode, SettingsVideoStabilizationMode.self, .off)
         overrideVideoStabilizationMode = container.decode(.overrideVideoStabilizationMode, Bool.self, false)
         fillFrame = container.decode(.fillFrame, Bool.self, false)
-        micOverride = container.decode(.micSwitch, Bool.self, false)
+        overrideMic = container.decode(.micSwitch, Bool.self, false)
         micId = container.decode(.micId, String.self, "")
     }
 
@@ -991,7 +991,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
             new.widgets.append(widget.clone())
         }
         new.videoSourceRotation = videoSourceRotation
-        new.micOverride = micOverride
+        new.overrideMic = overrideMic
         new.micId = micId
         return new
     }
@@ -3524,6 +3524,7 @@ class SettingsDebug: Codable, ObservableObject {
     var replay: Bool = false
     var recordSegmentLength: Double = 5.0
     @Published var builtinAudioAndVideoDelay: Double = 0.0
+    @Published var sceneOverrideMic: Bool = false
 
     enum CodingKeys: CodingKey {
         case logLevel,
@@ -3558,7 +3559,8 @@ class SettingsDebug: Codable, ObservableObject {
              srtlaBatchSendEnabled,
              replay,
              recordSegmentLength,
-             builtinAudioAndVideoDelay
+             builtinAudioAndVideoDelay,
+             sceneOverrideMic
     }
 
     func encode(to encoder: Encoder) throws {
@@ -3596,6 +3598,7 @@ class SettingsDebug: Codable, ObservableObject {
         try container.encode(.replay, replay)
         try container.encode(.recordSegmentLength, recordSegmentLength)
         try container.encode(.builtinAudioAndVideoDelay, builtinAudioAndVideoDelay)
+        try container.encode(.sceneOverrideMic, sceneOverrideMic)
     }
 
     init() {}
@@ -3640,6 +3643,7 @@ class SettingsDebug: Codable, ObservableObject {
         replay = (try? container.decode(Bool.self, forKey: .replay)) ?? false
         recordSegmentLength = (try? container.decode(Double.self, forKey: .recordSegmentLength)) ?? 5.0
         builtinAudioAndVideoDelay = (try? container.decode(Double.self, forKey: .builtinAudioAndVideoDelay)) ?? 0.0
+        sceneOverrideMic = (try? container.decode(Bool.self, forKey: .sceneOverrideMic)) ?? false
     }
 }
 

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -896,6 +896,8 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
     @Published var videoStabilizationMode: SettingsVideoStabilizationMode = .off
     @Published var overrideVideoStabilizationMode: Bool = false
     @Published var fillFrame: Bool = false
+    @Published var micSwitch: Bool = false
+    @Published var micId: String = ""
 
     init(name: String) {
         self.name = name
@@ -922,7 +924,9 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
              videoSourceRotation,
              videoStabilizationMode,
              overrideVideoStabilizationMode,
-             fillFrame
+             fillFrame,
+             micSwitch,
+             micId
     }
 
     func encode(to encoder: Encoder) throws {
@@ -944,6 +948,8 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         try container.encode(.videoStabilizationMode, videoStabilizationMode)
         try container.encode(.overrideVideoStabilizationMode, overrideVideoStabilizationMode)
         try container.encode(.fillFrame, fillFrame)
+        try container.encode(.micSwitch, micSwitch)
+        try container.encode(.micId, micId)
     }
 
     required init(from decoder: Decoder) throws {
@@ -965,6 +971,8 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         videoStabilizationMode = container.decode(.videoStabilizationMode, SettingsVideoStabilizationMode.self, .off)
         overrideVideoStabilizationMode = container.decode(.overrideVideoStabilizationMode, Bool.self, false)
         fillFrame = container.decode(.fillFrame, Bool.self, false)
+        micSwitch = container.decode(.micSwitch, Bool.self, false)
+        micId = container.decode(.micId, String.self, "")
     }
 
     func clone() -> SettingsScene {
@@ -983,6 +991,8 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
             new.widgets.append(widget.clone())
         }
         new.videoSourceRotation = videoSourceRotation
+        new.micSwitch = micSwitch
+        new.micId = micId
         return new
     }
 

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -896,7 +896,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
     @Published var videoStabilizationMode: SettingsVideoStabilizationMode = .off
     @Published var overrideVideoStabilizationMode: Bool = false
     @Published var fillFrame: Bool = false
-    @Published var micSwitch: Bool = false
+    @Published var micOverride: Bool = false
     @Published var micId: String = ""
 
     init(name: String) {
@@ -948,7 +948,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         try container.encode(.videoStabilizationMode, videoStabilizationMode)
         try container.encode(.overrideVideoStabilizationMode, overrideVideoStabilizationMode)
         try container.encode(.fillFrame, fillFrame)
-        try container.encode(.micSwitch, micSwitch)
+        try container.encode(.micSwitch, micOverride)
         try container.encode(.micId, micId)
     }
 
@@ -971,7 +971,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
         videoStabilizationMode = container.decode(.videoStabilizationMode, SettingsVideoStabilizationMode.self, .off)
         overrideVideoStabilizationMode = container.decode(.overrideVideoStabilizationMode, Bool.self, false)
         fillFrame = container.decode(.fillFrame, Bool.self, false)
-        micSwitch = container.decode(.micSwitch, Bool.self, false)
+        micOverride = container.decode(.micSwitch, Bool.self, false)
         micId = container.decode(.micId, String.self, "")
     }
 
@@ -991,7 +991,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject {
             new.widgets.append(widget.clone())
         }
         new.videoSourceRotation = videoSourceRotation
-        new.micSwitch = micSwitch
+        new.micOverride = micOverride
         new.micId = micId
         return new
     }

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonMicView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonMicView.swift
@@ -19,7 +19,7 @@ struct QuickButtonMicView: View {
                     }
                 }
                 .onChange(of: selectedMic) { mic in
-                    model.selectMicById(id: mic.id)
+                    model.manualSelectMicById(id: mic.id)
                 }
                 .pickerStyle(.inline)
                 .labelsHidden()

--- a/Moblin/View/Settings/Debug/DebugAudioSettingsView.swift
+++ b/Moblin/View/Settings/Debug/DebugAudioSettingsView.swift
@@ -7,7 +7,7 @@ struct DebugAudioSettingsView: View {
         Form {
             Section {
                 Toggle("Remove wind noise", isOn: $debug.removeWindNoise)
-                Toggle("Scene mic override", isOn: $debug.sceneOverrideMic)
+                Toggle("Scene override mic", isOn: $debug.sceneOverrideMic)
             } footer: {
                 Text("App restart needed to take effect.")
             }

--- a/Moblin/View/Settings/Debug/DebugAudioSettingsView.swift
+++ b/Moblin/View/Settings/Debug/DebugAudioSettingsView.swift
@@ -7,6 +7,7 @@ struct DebugAudioSettingsView: View {
         Form {
             Section {
                 Toggle("Remove wind noise", isOn: $debug.removeWindNoise)
+                Toggle("Scene mic override", isOn: $debug.sceneOverrideMic)
             } footer: {
                 Text("App restart needed to take effect.")
             }

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -206,7 +206,7 @@ struct SceneSettingsView: View {
                         }
                     }
                 } header: {
-                    Text("Mic override")
+                    Text("Override mic")
                 } footer: {
                     Text("""
                     Use the selected mic, when switching to the scene and the mic is available.

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -114,6 +114,10 @@ struct SceneSettingsView: View {
         model.sceneUpdated(attachCamera: true, updateRemoteScene: false)
     }
 
+    private func onMicChange(micId: String) {
+        scene.micId = micId
+    }
+
     var body: some View {
         Form {
             NavigationLink {
@@ -176,6 +180,40 @@ struct SceneSettingsView: View {
                 Text("""
                 Enable Override video stabilization to override Settings → Camera → Video \
                 stabilization in this scene.
+                """)
+            }
+            Section {
+                Toggle("Automatic Switch", isOn: $scene.micSwitch)
+                    .onChange(of: scene.micSwitch) { _ in
+                    }
+                if scene.micSwitch {
+                    NavigationLink {
+                        InlinePickerView(
+                            title: String(localized: "Name"),
+                            onChange: onMicChange,
+                            items: model.mics.map {
+                                InlinePickerItem(id: $0.id, text: $0.name)
+                            },
+                            selectedId: scene.micId
+                        )
+                    } label: {
+                        HStack {
+                            Text("Name")
+                            Spacer()
+                            if !model.isSceneVideoSourceActive(scene: scene) {
+                                Image(systemName: "cable.connector.slash")
+                            }
+                            Text(model.mics.first(where: { mic in mic.id == scene.micId })?.name ?? "None")
+                                .foregroundColor(.gray)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            } header: {
+                Text("Audio source")
+            } footer: {
+                Text("""
+                Try to use this Audio source, when switching to the scene and the selected audio source is available.
                 """)
             }
             Section {

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -183,10 +183,8 @@ struct SceneSettingsView: View {
                 """)
             }
             Section {
-                Toggle("Automatic Switch", isOn: $scene.micSwitch)
-                    .onChange(of: scene.micSwitch) { _ in
-                    }
-                if scene.micSwitch {
+                Toggle("Enabled", isOn: $scene.micOverride)
+                if scene.micOverride {
                     NavigationLink {
                         InlinePickerView(
                             title: String(localized: "Name"),
@@ -200,20 +198,17 @@ struct SceneSettingsView: View {
                         HStack {
                             Text("Name")
                             Spacer()
-                            if !model.isSceneVideoSourceActive(scene: scene) {
-                                Image(systemName: "cable.connector.slash")
-                            }
-                            Text(model.mics.first(where: { mic in mic.id == scene.micId })?.name ?? "None")
+                            Text(model.getMicById(id: scene.micId)?.name ?? "Unknown 😢")
                                 .foregroundColor(.gray)
                                 .lineLimit(1)
                         }
                     }
                 }
             } header: {
-                Text("Audio source")
+                Text("Mic override")
             } footer: {
                 Text("""
-                Try to use this Audio source, when switching to the scene and the selected audio source is available.
+                Use the selected mic, when switching to the scene and the mic is available.
                 """)
             }
             Section {

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -182,34 +182,36 @@ struct SceneSettingsView: View {
                 stabilization in this scene.
                 """)
             }
-            Section {
-                Toggle("Enabled", isOn: $scene.micOverride)
-                if scene.micOverride {
-                    NavigationLink {
-                        InlinePickerView(
-                            title: String(localized: "Name"),
-                            onChange: onMicChange,
-                            items: model.mics.map {
-                                InlinePickerItem(id: $0.id, text: $0.name)
-                            },
-                            selectedId: scene.micId
-                        )
-                    } label: {
-                        HStack {
-                            Text("Name")
-                            Spacer()
-                            Text(model.getMicById(id: scene.micId)?.name ?? "Unknown 😢")
-                                .foregroundColor(.gray)
-                                .lineLimit(1)
+            if database.debug.sceneOverrideMic {
+                Section {
+                    Toggle("Enabled", isOn: $scene.overrideMic)
+                    if scene.overrideMic {
+                        NavigationLink {
+                            InlinePickerView(
+                                title: String(localized: "Name"),
+                                onChange: onMicChange,
+                                items: model.mics.map {
+                                    InlinePickerItem(id: $0.id, text: $0.name)
+                                },
+                                selectedId: scene.micId
+                            )
+                        } label: {
+                            HStack {
+                                Text("Name")
+                                Spacer()
+                                Text(model.getMicById(id: scene.micId)?.name ?? "Unknown 😢")
+                                    .foregroundColor(.gray)
+                                    .lineLimit(1)
+                            }
                         }
                     }
+                } header: {
+                    Text("Mic override")
+                } footer: {
+                    Text("""
+                    Use the selected mic, when switching to the scene and the mic is available.
+                    """)
                 }
-            } header: {
-                Text("Mic override")
-            } footer: {
-                Text("""
-                Use the selected mic, when switching to the scene and the mic is available.
-                """)
             }
             Section {
                 List {

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -115,6 +115,10 @@ struct SceneSettingsView: View {
     }
 
     private func onMicChange(micId: String) {
+        let currentScene = model.getSelectedScene()
+        if currentScene == scene {
+            model.selectMicById(id: micId)
+        }
         scene.micId = micId
     }
 
@@ -185,6 +189,11 @@ struct SceneSettingsView: View {
             if database.debug.sceneOverrideMic {
                 Section {
                     Toggle("Enabled", isOn: $scene.overrideMic)
+                        .onChange(of: scene.overrideMic) { _ in
+                            if model.getSelectedScene() == scene && !scene.overrideMic {
+                                model.selectMicById(id: model.previousMic.id)
+                            }
+                        }
                     if scene.overrideMic {
                         NavigationLink {
                             InlinePickerView(

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -115,11 +115,24 @@ struct SceneSettingsView: View {
     }
 
     private func onMicChange(micId: String) {
-        let currentScene = model.getSelectedScene()
-        if currentScene == scene {
+        if model.getSelectedScene() === scene && scene.overrideMic {
             model.selectMicById(id: micId)
         }
         scene.micId = micId
+    }
+
+    private func onOverrideMicChange(overrideMic _: Bool) {
+        if model.getSelectedScene() === scene {
+            if scene.overrideMic && scene.micId != "" {
+                model.selectMicById(id: scene.micId)
+            } else {
+                if model.isMicAvailableById(id: model.previousMic.id) {
+                    model.selectMicById(id: model.previousMic.id)
+                } else {
+                    model.setMicFromSettings()
+                }
+            }
+        }
     }
 
     var body: some View {
@@ -190,9 +203,7 @@ struct SceneSettingsView: View {
                 Section {
                     Toggle("Enabled", isOn: $scene.overrideMic)
                         .onChange(of: scene.overrideMic) { _ in
-                            if model.getSelectedScene() == scene && !scene.overrideMic {
-                                model.selectMicById(id: model.previousMic.id)
-                            }
+                            onOverrideMicChange(overrideMic: scene.overrideMic)
                         }
                     if scene.overrideMic {
                         NavigationLink {


### PR DESCRIPTION
added an toggle in scene settings to enable automatic mic switching and a mic selection. if enabled the mic will be switched automatically when scene switching occurs given that the selected mic is available and a different one than the currently active one.