### PR TITLE
Fix Chat Reply Emotes Display

### DIFF
--- a/Moblin/Platforms/Twitch/TwitchChat.swift
+++ b/Moblin/Platforms/Twitch/TwitchChat.swift
@@ -596,7 +596,7 @@ final class TwitchChat {
         webSocket.send(string: "PONG \(message.parameters.joined(separator: " "))")
     }
 
-    private func createHighlight(message: ChatMessage, emotes: [ChatMessageEmote]) -> ChatHighlight? {
+    private func createHighlight(message: ChatMessage, emotes _: [ChatMessageEmote]) -> ChatHighlight? {
         if message.announcement {
             return ChatHighlight.makeAnnouncement()
         } else if message.firstMessage {
@@ -604,7 +604,7 @@ final class TwitchChat {
         } else if let sender = message.replySender, let text = message.replyText {
             return ChatHighlight.makeReply(
                 user: sender,
-                segments: createSegments(text: text, emotes: emotes, emotesManager: self.emotes, bits: nil)
+                segments: createSegments(text: text, emotes: [], emotesManager: emotes, bits: nil)
             )
         } else {
             return nil

--- a/Moblin/Platforms/Twitch/TwitchChat.swift
+++ b/Moblin/Platforms/Twitch/TwitchChat.swift
@@ -574,7 +574,7 @@ final class TwitchChat {
             isSubscriber: message.subscriber,
             isModerator: message.moderator,
             bits: message.bits,
-            highlight: createHighlight(message: message, emotes: emotes)
+            highlight: createHighlight(message: message)
         )
     }
 
@@ -596,7 +596,7 @@ final class TwitchChat {
         webSocket.send(string: "PONG \(message.parameters.joined(separator: " "))")
     }
 
-    private func createHighlight(message: ChatMessage, emotes _: [ChatMessageEmote]) -> ChatHighlight? {
+    private func createHighlight(message: ChatMessage) -> ChatHighlight? {
         if message.announcement {
             return ChatHighlight.makeAnnouncement()
         } else if message.firstMessage {

--- a/Moblin/Various/ChatPost.swift
+++ b/Moblin/Various/ChatPost.swift
@@ -42,6 +42,7 @@ struct ChatHighlight {
             segment.text ?? (segment.url != nil ? "[emote]" : nil)
         }.joined()
     }
+
     var titleForWatchDisplay: String {
         titleSegments.compactMap { segment in
             segment.text

--- a/Moblin/Various/ChatPost.swift
+++ b/Moblin/Various/ChatPost.swift
@@ -37,13 +37,11 @@ struct ChatHighlight {
     let barColor: Color
     let image: String
     let titleSegments: [ChatPostSegment]
-
     var title: String {
         titleSegments.compactMap { segment in
             segment.text ?? (segment.url != nil ? "[emote]" : nil)
         }.joined()
     }
-
     var titleForWatchDisplay: String {
         titleSegments.compactMap { segment in
             segment.text
@@ -54,11 +52,9 @@ struct ChatHighlight {
         let prefixText = String(localized: "Replying to \(user): ")
         var replySegments: [ChatPostSegment] = []
         var id = 0
-
         // Add prefix text segment
         replySegments.append(ChatPostSegment(id: id, text: prefixText))
         id += 1
-
         // Add original message segments (limited for preview)
         var totalLength = prefixText.count
         for segment in segments {
@@ -78,6 +74,7 @@ struct ChatHighlight {
                 } else {
                     replySegments.append(ChatPostSegment(id: id, text: "..."))
                 }
+                id += 1
                 break
             }
             totalLength += segmentLength

--- a/Moblin/Various/Model/ModelKick.swift
+++ b/Moblin/Various/Model/ModelKick.swift
@@ -74,7 +74,7 @@ extension Model {
                               kind: kind ?? .redemption,
                               barColor: color,
                               image: image ?? "medal",
-                              title: title
+                              titleSegments: [ChatPostSegment(id: 0, text: title)]
                           ),
                           live: true)
     }

--- a/Moblin/Various/Model/ModelKick.swift
+++ b/Moblin/Various/Model/ModelKick.swift
@@ -122,7 +122,7 @@ extension Model: KickOusherDelegate {
     func kickPusherSubscription(event: SubscriptionEvent) {
         DispatchQueue.main.async {
             let text = String(localized: "just subscribed! They've been subscribed for \(event.months) months!")
-            self.makeToast(title: "\(event.username) \(text)")
+            self.makeToast(title: "🎉 \(event.username) \(text)")
             self.appendKickChatAlertMessage(
                 user: event.username,
                 text: text,
@@ -141,7 +141,7 @@ extension Model: KickOusherDelegate {
                 just gifted \(event.gifted_usernames.count) subscription(s)! \
                 They've gifted \(event.gifter_total) in total!
                 """)
-            self.makeToast(title: "\(user) \(text)")
+            self.makeToast(title: "🎁 \(user) \(text)")
             self.appendKickChatAlertMessage(
                 user: user,
                 text: text,
@@ -157,7 +157,7 @@ extension Model: KickOusherDelegate {
             let user = event.username
             let baseText = String(localized: "redeemed \(event.reward_title)")
             let text = event.user_input.isEmpty ? baseText : "\(baseText): \(event.user_input)"
-            self.makeToast(title: "\(user) \(text)")
+            self.makeToast(title: "🎁 \(user) \(text)")
             self.appendKickChatAlertMessage(
                 user: user,
                 text: text,
@@ -172,7 +172,7 @@ extension Model: KickOusherDelegate {
         DispatchQueue.main.async {
             let user = event.host_username
             let text = String(localized: "is now hosting with \(event.number_viewers) viewers!")
-            self.makeToast(title: "\(user) \(text)")
+            self.makeToast(title: "📺 \(user) \(text)")
             self.appendKickChatAlertMessage(
                 user: user,
                 text: text,
@@ -186,7 +186,7 @@ extension Model: KickOusherDelegate {
     func kickPusherUserBanned(event: UserBannedEvent) {
         DispatchQueue.main.async {
             let text = String(localized: "was banned from chat!")
-            self.makeToast(title: "\(event.user.username) \(text)")
+            self.makeToast(title: "🚫 \(event.user.username) \(text)")
             self.appendKickChatAlertMessage(
                 user: event.user.username,
                 text: text,

--- a/Moblin/Various/Model/ModelTwitch.swift
+++ b/Moblin/Various/Model/ModelTwitch.swift
@@ -474,7 +474,7 @@ extension Model: TwitchEventSubDelegate {
                               kind: kind ?? .redemption,
                               barColor: color,
                               image: image ?? "medal",
-                              title: title
+                              titleSegments: [ChatPostSegment(id: 0, text: title)]
                           ),
                           live: true)
     }

--- a/Moblin/View/ControlBar/QuickButton/QuickButtonChatView.swift
+++ b/Moblin/View/ControlBar/QuickButton/QuickButtonChatView.swift
@@ -6,6 +6,10 @@ import WrappingHStack
 private struct HighlightMessageView: View {
     let highlight: ChatHighlight
 
+    private func frameHeightEmotes() -> CGFloat {
+        return CGFloat(20 * 1.7) // Using default font size
+    }
+
     var body: some View {
         WrappingHStack(
             alignment: .leading,
@@ -15,7 +19,24 @@ private struct HighlightMessageView: View {
         ) {
             Image(systemName: highlight.image)
             Text(" ")
-            Text(highlight.title)
+
+            ForEach(highlight.titleSegments, id: \.id) { segment in
+                if let text = segment.text {
+                    Text(text)
+                        .foregroundColor(highlight.messageColor())
+                }
+                if let url = segment.url {
+                    CacheAsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                        EmptyView()
+                    }
+                    .frame(height: frameHeightEmotes())
+                    Text(" ")
+                }
+            }
         }
         .foregroundColor(highlight.messageColor())
         .padding([.leading], 5)

--- a/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
+++ b/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
@@ -28,6 +28,7 @@ private struct HighlightMessageView: View {
     private func frameHeightEmotes() -> CGFloat {
         return CGFloat(chat.fontSize * 1.7)
     }
+
     var body: some View {
         WrappingHStack(
             alignment: .leading,

--- a/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
+++ b/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
@@ -28,7 +28,6 @@ private struct HighlightMessageView: View {
     private func frameHeightEmotes() -> CGFloat {
         return CGFloat(chat.fontSize * 1.7)
     }
-
     var body: some View {
         WrappingHStack(
             alignment: .leading,
@@ -38,7 +37,6 @@ private struct HighlightMessageView: View {
         ) {
             Image(systemName: highlight.image)
             Text(" ")
-
             ForEach(highlight.titleSegments, id: \.id) { segment in
                 if let text = segment.text {
                     Text(text)

--- a/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
+++ b/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
@@ -25,6 +25,10 @@ private struct HighlightMessageView: View {
         }
     }
 
+    private func frameHeightEmotes() -> CGFloat {
+        return CGFloat(chat.fontSize * 1.7)
+    }
+
     var body: some View {
         WrappingHStack(
             alignment: .leading,
@@ -34,9 +38,34 @@ private struct HighlightMessageView: View {
         ) {
             Image(systemName: highlight.image)
             Text(" ")
-            Text(highlight.title)
+
+            ForEach(highlight.titleSegments, id: \.id) { segment in
+                if let text = segment.text {
+                    Text(text)
+                        .foregroundColor(highlight.messageColor(defaultColor: chat.messageColor.color()))
+                }
+                if let url = segment.url {
+                    if chat.animatedEmotes {
+                        WebImage(url: url)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .padding([.top, .bottom], chat.shadowColorEnabled ? 1.5 : 0)
+                            .frame(height: frameHeightEmotes())
+                    } else {
+                        CacheAsyncImage(url: url) { image in
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            EmptyView()
+                        }
+                        .padding([.top, .bottom], chat.shadowColorEnabled ? 1.5 : 0)
+                        .frame(height: frameHeightEmotes())
+                    }
+                    Text(" ")
+                }
+            }
         }
-        .foregroundColor(highlight.messageColor(defaultColor: chat.messageColor.color()))
         .stroke(color: shadowColor(), width: chat.shadowColorEnabled ? borderWidth : 0)
         .padding([.leading], 5)
         .font(.system(size: CGFloat(chat.fontSize)))

--- a/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
+++ b/Moblin/View/Stream/Overlay/StreamOverlayChatView.swift
@@ -45,23 +45,11 @@ private struct HighlightMessageView: View {
                         .foregroundColor(highlight.messageColor(defaultColor: chat.messageColor.color()))
                 }
                 if let url = segment.url {
-                    if chat.animatedEmotes {
-                        WebImage(url: url)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .padding([.top, .bottom], chat.shadowColorEnabled ? 1.5 : 0)
-                            .frame(height: frameHeightEmotes())
-                    } else {
-                        CacheAsyncImage(url: url) { image in
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                        } placeholder: {
-                            EmptyView()
-                        }
+                    WebImage(url: url)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
                         .padding([.top, .bottom], chat.shadowColorEnabled ? 1.5 : 0)
                         .frame(height: frameHeightEmotes())
-                    }
                     Text(" ")
                 }
             }


### PR DESCRIPTION
  Problem: Chat reply previews showed [emote] text instead of actual emote images.

  Solution:
  - Updated ChatHighlight to use segment-based rendering like regular messages
  - Fixed Twitch reply emote processing bug
  - Now shows actual emote images in reply previews across all chat views
