### PR TITLE
channel ID display and rate limiting to the Kick settings:

### DIFF
--- a/Moblin/Platforms/Kick/KickPusher.swift
+++ b/Moblin/Platforms/Kick/KickPusher.swift
@@ -187,6 +187,8 @@ protocol KickOusherDelegate: AnyObject {
     func kickPusherRewardRedeemed(event: RewardRedeemedEvent)
     func kickPusherStreamHost(event: StreamHostEvent)
     func kickPusherUserBanned(event: UserBannedEvent)
+    func kickPusherChannelInfoFetched(channelId: String)
+    func kickPusherChannelInfoFailed()
 }
 
 final class KickPusher: NSObject {
@@ -228,6 +230,7 @@ final class KickPusher: NSObject {
                     return
                 }
                 guard let channelInfo else {
+                    self.delegate?.kickPusherChannelInfoFailed()
                     DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                         self.getInfoAndConnect()
                     }
@@ -235,6 +238,7 @@ final class KickPusher: NSObject {
                 }
                 self.gotInfo = true
                 self.channelId = String(channelInfo.chatroom.id)
+                self.delegate?.kickPusherChannelInfoFetched(channelId: self.channelId)
                 self.connect()
             }
         }

--- a/Moblin/Various/Model/ModelKick.swift
+++ b/Moblin/Various/Model/ModelKick.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftUI
 
+extension NSNotification.Name {
+    static let kickChannelInfoUpdated = NSNotification.Name("KickChannelInfoUpdated")
+}
+
 private enum KickSendError: Error {
     case notLoggedIn
     case channelNotSet
@@ -50,6 +54,7 @@ extension Model {
     }
 
     func kickChannelNameUpdated() {
+        stream.kickChatroomId = ""
         reloadKickPusher()
         reloadKickViewers()
         resetChat()
@@ -238,6 +243,21 @@ extension Model: KickOusherDelegate {
                 color: .red,
                 image: "nosign"
             )
+        }
+    }
+
+    func kickPusherChannelInfoFetched(channelId: String) {
+        updateKickChannelInfo(channelId: channelId)
+    }
+
+    func kickPusherChannelInfoFailed() {
+        updateKickChannelInfo(channelId: "")
+    }
+
+    private func updateKickChannelInfo(channelId: String) {
+        DispatchQueue.main.async {
+            self.stream.kickChatroomId = channelId
+            NotificationCenter.default.post(name: .kickChannelInfoUpdated, object: nil)
         }
     }
 }


### PR DESCRIPTION
Channel ID Display: Shows the fetched channel ID under the channel name
   field, or "Channel not found" if invalid
Rate Limiting: 2.5-second cooldown on channel name changes to prevent
  API rate limiting