### PR TITLE
Kick: improve auth: auto-click login button & username retrieval

### DIFF
--- a/Moblin/Platforms/Kick/KickApi.swift
+++ b/Moblin/Platforms/Kick/KickApi.swift
@@ -31,6 +31,10 @@ struct KickChannel: Codable {
     let subscriber_badges: [SubscriberBadge]?
 }
 
+struct KickUserData: Codable {
+    let username: String
+}
+
 func getKickChannelInfo(channelName: String) async throws -> KickChannel {
     guard let url = URL(string: "https://kick.com/api/v1/channels/\(channelName)") else {
         throw "Invalid URL"
@@ -54,6 +58,25 @@ func getKickChannelInfo(channelName: String, onComplete: @escaping (KickChannel?
             return
         }
         onComplete(try? JSONDecoder().decode(KickChannel.self, from: data))
+    }
+    .resume()
+}
+
+func getKickUserData(accessToken: String, onComplete: @escaping (KickUserData?) -> Void) {
+    guard let url = URL(string: "https://kick.com/api/v1/user") else {
+        onComplete(nil)
+        return
+    }
+    var request = URLRequest(url: url)
+    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    
+    URLSession.shared.dataTask(with: request) { data, response, error in
+        guard error == nil, let data, response?.http?.isSuccessful == true else {
+            onComplete(nil)
+            return
+        }
+        onComplete(try? JSONDecoder().decode(KickUserData.self, from: data))
     }
     .resume()
 }

--- a/Moblin/Platforms/Kick/KickApi.swift
+++ b/Moblin/Platforms/Kick/KickApi.swift
@@ -70,7 +70,7 @@ func getKickUserData(accessToken: String, onComplete: @escaping (KickUserData?) 
     var request = URLRequest(url: url)
     request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
-    
+
     URLSession.shared.dataTask(with: request) { data, response, error in
         guard error == nil, let data, response?.http?.isSuccessful == true else {
             onComplete(nil)

--- a/Moblin/Various/Settings.swift
+++ b/Moblin/Various/Settings.swift
@@ -721,7 +721,7 @@ class SettingsStream: Codable, Identifiable, Equatable, ObservableObject, Named 
     var twitchLoggedIn: Bool = false
     var twitchRewards: [SettingsStreamTwitchReward] = []
     @Published var twitchSendMessagesTo: Bool = true
-    var kickChannelName: String = ""
+    @Published var kickChannelName: String = ""
     @Published var kickChannelId: String?
     @Published var kickSlug: String?
     var kickAccessToken: String = ""

--- a/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
+++ b/Moblin/View/Settings/Streams/Stream/Kick/StreamKickSettingsView.swift
@@ -61,14 +61,14 @@ private struct AuthenticationView: View {
     private func handleAccessToken(accessToken: String) {
         stream.kickAccessToken = accessToken
         stream.kickLoggedIn = true
-        
+
         getKickUserData(accessToken: accessToken) { userData in
             DispatchQueue.main.async {
                 if let userData {
                     self.stream.kickChannelName = userData.username
                     self.stream.kickChannelId = nil
                     self.stream.kickSlug = nil
-                    
+
                     getKickChannelInfo(channelName: userData.username) { channelInfo in
                         DispatchQueue.main.async {
                             if let channelInfo {
@@ -120,7 +120,7 @@ private struct KickWebView: UIViewRepresentable {
             self.onAccessToken = onAccessToken
         }
 
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
             if !loginButtonClicked {
                 detectAndClickLoginButton(webView)
             }


### PR DESCRIPTION
This PR refines the Kick authentication experience by automating the login process and ensuring we store accurate channel information after a successful login.

What i changed:
1)Automatically click the Kick “Log in” button in AuthView (embedded js script locates the login button via its data-testID attribute
2) Fetch the authenticated user’s username directly from Kick’s /api/v1/user endpoint upon login and update in the model.

I tested it and works pretty well but I am awaiting Erik’s legendary refactor skills™.

<3 