### PR TITLE
feat: add customizable looping mute audio feedback and localized overlay

### DIFF
--- a/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
+++ b/Moblin/Media/HaishinKit/Media/Audio/AudioUnit.swift
@@ -90,11 +90,16 @@ func makeChannelMap(
 }
 
 final class AudioUnit: NSObject, @unchecked Sendable {
+    static var onAudioSample: ((CMSampleBuffer) -> Void)?
     let encoder = AudioEncoder(lockQueue: processorPipelineQueue)
     var previewEncoder: AudioEncoder?
     private var input: AVCaptureDeviceInput?
     private var output: AVCaptureAudioDataOutput?
     var muted = false
+    private var muteLoopFileBuffer: AVAudioPCMBuffer?
+    private var resampledMuteLoopBuffer: AVAudioPCMBuffer?
+    private var muteLoopPlayIndex: Int = 0
+    private var muteLoopEnabled = false
     var gain: Float = 1.0
     weak var processor: Processor?
     private var selectedBufferedAudioId: UUID?
@@ -279,7 +284,17 @@ final class AudioUnit: NSObject, @unchecked Sendable {
                                        _ sampleBuffer: CMSampleBuffer,
                                        _ presentationTimeStamp: CMTime)
     {
-        guard let sampleBuffer = sampleBuffer.muted(muted)?.withGain(gain) else {
+        var sampleBuffer = sampleBuffer
+        if muted {
+            if muteLoopEnabled, let loopBuffer = injectMuteLoop(sampleBuffer: sampleBuffer) {
+                sampleBuffer = loopBuffer
+            } else if let silenceBuffer = sampleBuffer.muted(true) {
+                sampleBuffer = silenceBuffer
+            } else {
+                return
+            }
+        }
+        guard let sampleBuffer = sampleBuffer.withGain(gain) else {
             return
         }
         if shouldUpdateAudioLevel(sampleBuffer) {
@@ -360,6 +375,9 @@ extension AudioUnit: AVCaptureAudioDataOutputSampleBufferDelegate {
         didOutput sampleBuffer: CMSampleBuffer,
         from _: AVCaptureConnection
     ) {
+        if let onAudioSample = AudioUnit.onAudioSample {
+            onAudioSample(sampleBuffer)
+        }
         guard let processor else {
             return
         }
@@ -373,6 +391,200 @@ extension AudioUnit: AVCaptureAudioDataOutputSampleBufferDelegate {
             return
         }
         appendNewSampleBuffer(processor, sampleBuffer, presentationTimeStamp)
+    }
+
+    func setMuteLoop(url: URL?, enabled: Bool) {
+        processorPipelineQueue.async {
+            self.muteLoopEnabled = enabled
+            guard enabled, let url else {
+                self.muteLoopFileBuffer = nil
+                self.resampledMuteLoopBuffer = nil
+                self.muteLoopPlayIndex = 0
+                return
+            }
+            if let file = try? AVAudioFile(forReading: url) {
+                let format = file.processingFormat
+                let frameCount = AVAudioFrameCount(file.length)
+                if let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) {
+                    do {
+                        try file.read(into: buffer)
+                        self.muteLoopFileBuffer = buffer
+                        self.resampledMuteLoopBuffer = nil
+                        self.muteLoopPlayIndex = 0
+                        logger.info("audio-unit: Loaded mute loop file: \(url.lastPathComponent)")
+                    } catch {
+                        logger.info("audio-unit: Failed to read mute loop file: \(error)")
+                    }
+                }
+            } else {
+                logger.info("audio-unit: Failed to open mute loop file: \(url)")
+            }
+        }
+    }
+
+    private func injectMuteLoop(sampleBuffer: CMSampleBuffer) -> CMSampleBuffer? {
+        guard let fileBuffer = muteLoopFileBuffer else {
+            return sampleBuffer.muted(true)
+        }
+        guard let formatDescription = sampleBuffer.formatDescription else {
+            return sampleBuffer.muted(true)
+        }
+        let targetFormat = AVAudioFormat(cmAudioFormatDescription: formatDescription)
+
+        if resampledMuteLoopBuffer == nil || resampledMuteLoopBuffer?.format != targetFormat {
+            resampledMuteLoopBuffer = resampleBuffer(from: fileBuffer, to: targetFormat)
+            muteLoopPlayIndex = 0
+        }
+
+        guard let resampled = resampledMuteLoopBuffer else {
+            return sampleBuffer.muted(true)
+        }
+
+        let frameCount = Int(sampleBuffer.numSamples)
+        guard frameCount > 0 else {
+            return sampleBuffer
+        }
+
+        var bufferList = AudioBufferList()
+        var blockBufferOut: CMBlockBuffer?
+        let status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: &bufferList,
+            bufferListSize: MemoryLayout<AudioBufferList>.size,
+            blockBufferAllocator: nil,
+            blockBufferMemoryAllocator: nil,
+            flags: 1,
+            blockBufferOut: &blockBufferOut
+        )
+
+        guard status == noErr else {
+            return sampleBuffer.muted(true)
+        }
+
+        let resampledLength = Int(resampled.frameLength)
+        guard resampledLength > 0 else {
+            return sampleBuffer.muted(true)
+        }
+
+        let isFloat = resampled.format.commonFormat == .pcmFormatFloat32
+
+        if isFloat {
+            guard let sourceFloatChannels = resampled.floatChannelData else {
+                return sampleBuffer.muted(true)
+            }
+
+            let buffers = UnsafeBufferPointer(
+                start: &bufferList.mBuffers,
+                count: Int(bufferList.mNumberBuffers)
+            )
+            for (channel, buffer) in buffers.enumerated() {
+                guard let destData = buffer.mData else { continue }
+                let destFloat = destData.assumingMemoryBound(to: Float.self)
+                let numChannels = Int(buffer.mNumberChannels)
+
+                for frame in 0 ..< frameCount {
+                    let sourceFrame = (muteLoopPlayIndex + frame) % resampledLength
+                    for ch in 0 ..< numChannels {
+                        let sourceCh = min(
+                            channel * numChannels + ch,
+                            Int(resampled.format.channelCount) - 1
+                        )
+                        destFloat[frame * numChannels + ch] = sourceFloatChannels[sourceCh][sourceFrame]
+                    }
+                }
+            }
+        } else {
+            guard let sourceInt16Channels = resampled.int16ChannelData else {
+                return sampleBuffer.muted(true)
+            }
+            let buffers = UnsafeBufferPointer(
+                start: &bufferList.mBuffers,
+                count: Int(bufferList.mNumberBuffers)
+            )
+            for (channel, buffer) in buffers.enumerated() {
+                guard let destData = buffer.mData else { continue }
+                let destInt16 = destData.assumingMemoryBound(to: Int16.self)
+                let numChannels = Int(buffer.mNumberChannels)
+
+                for frame in 0 ..< frameCount {
+                    let sourceFrame = (muteLoopPlayIndex + frame) % resampledLength
+                    for ch in 0 ..< numChannels {
+                        let sourceCh = min(
+                            channel * numChannels + ch,
+                            Int(resampled.format.channelCount) - 1
+                        )
+                        destInt16[frame * numChannels + ch] = sourceInt16Channels[sourceCh][sourceFrame]
+                    }
+                }
+            }
+        }
+
+        muteLoopPlayIndex = (muteLoopPlayIndex + frameCount) % resampledLength
+        return sampleBuffer
+    }
+
+    private func resampleBuffer(from sourceBuffer: AVAudioPCMBuffer,
+                                to targetFormat: AVAudioFormat) -> AVAudioPCMBuffer?
+    {
+        let sourceFormat = sourceBuffer.format
+        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+            logger.info("audio-unit: Failed to create resampler from \(sourceFormat) to \(targetFormat)")
+            return nil
+        }
+
+        let ratio = targetFormat.sampleRate / sourceFormat.sampleRate
+        let targetCapacity = AVAudioFrameCount(Double(sourceBuffer.frameLength) * ratio) + 100
+
+        guard let destBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: targetCapacity) else {
+            return nil
+        }
+
+        var error: NSError?
+        var inputPosition = 0
+
+        let status = converter.convert(to: destBuffer, error: &error) { inNumPackets, outStatus in
+            let remainingFrames = Int(sourceBuffer.frameLength) - inputPosition
+            if remainingFrames <= 0 {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+
+            let framesToCopy = min(Int(inNumPackets), remainingFrames)
+            outStatus.pointee = .haveData
+
+            guard let tempBuffer = AVAudioPCMBuffer(
+                pcmFormat: sourceFormat,
+                frameCapacity: AVAudioFrameCount(framesToCopy)
+            ) else {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            tempBuffer.frameLength = AVAudioFrameCount(framesToCopy)
+
+            if sourceFormat.commonFormat == .pcmFormatFloat32 {
+                if let srcChannels = sourceBuffer.floatChannelData,
+                   let dstChannels = tempBuffer.floatChannelData
+                {
+                    for channel in 0 ..< Int(sourceFormat.channelCount) {
+                        dstChannels[channel].assign(
+                            from: srcChannels[channel].advanced(by: inputPosition),
+                            count: framesToCopy
+                        )
+                    }
+                }
+            }
+
+            inputPosition += framesToCopy
+            return tempBuffer
+        }
+
+        if let error {
+            logger.info("audio-unit: Resampling error: \(error)")
+            return nil
+        }
+
+        return destBuffer
     }
 }
 

--- a/Moblin/Media/HaishinKit/Media/Processor.swift
+++ b/Moblin/Media/HaishinKit/Media/Processor.swift
@@ -91,6 +91,12 @@ final class Processor: @unchecked Sendable {
         }
     }
 
+    func setMuteLoop(url: URL?, enabled: Bool) {
+        processorControlQueue.async {
+            self.audio.setMuteLoop(url: url, enabled: enabled)
+        }
+    }
+
     func setAudioGain(gain: Float) {
         processorControlQueue.async {
             self.audio.gain = gain

--- a/Moblin/Various/Media.swift
+++ b/Moblin/Various/Media.swift
@@ -670,6 +670,10 @@ final class Media: NSObject, @unchecked Sendable {
         processor?.setHasAudio(value: !on)
     }
 
+    func setMuteLoop(url: URL?, enabled: Bool) {
+        processor?.setMuteLoop(url: url, enabled: enabled)
+    }
+
     func setAudioGain(gain: Float) {
         processor?.setAudioGain(gain: gain)
     }

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -2952,6 +2952,20 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         updateTextEffects(now: .now, timestamp: .now)
         forceUpdateTextEffects()
         remoteControlStateChanged(state: .init(muted: isMuteOn))
+        if isMuteOn {
+            if database.audio.muteSoundEnabled {
+                let soundId = database.audio.muteSoundId ?? database.alertsMediaGallery.bundledSounds[0].id
+                if let url = getAlertSoundUrl(soundId: soundId) {
+                    media.setMuteLoop(url: url, enabled: true)
+                } else {
+                    media.setMuteLoop(url: nil, enabled: false)
+                }
+            } else {
+                media.setMuteLoop(url: nil, enabled: false)
+            }
+        } else {
+            media.setMuteLoop(url: nil, enabled: false)
+        }
     }
 
     private func makeFlameRedToast() {

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -849,6 +849,7 @@ private nonisolated(unsafe) let allBundledAlertsMediaGalleryImages = [
 ]
 
 private nonisolated(unsafe) let allBundledAlertsMediaGallerySounds = [
+    SettingsAlertsMediaGalleryItem(name: "Mute loop"),
     SettingsAlertsMediaGalleryItem(name: "Notification 2"),
     SettingsAlertsMediaGalleryItem(name: "Boing"),
     SettingsAlertsMediaGalleryItem(name: "Cash register"),

--- a/Moblin/Various/Settings/SettingsAudio.swift
+++ b/Moblin/Various/Settings/SettingsAudio.swift
@@ -164,18 +164,24 @@ class SettingsAudioOutputToInputChannelsMap: Codable {
 class SettingsAudio: Codable, ObservableObject {
     var outputToInputChannelsMap: SettingsAudioOutputToInputChannelsMap = .init()
     @Published var gainDb: Float = 0.0
+    @Published var muteSoundEnabled: Bool = false
+    var muteSoundId: UUID?
 
     init() {}
 
     enum CodingKeys: CodingKey {
         case audioOutputToInputChannelsMap
         case gainDb
+        case muteSoundEnabled
+        case muteSoundId
     }
 
     func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(.audioOutputToInputChannelsMap, outputToInputChannelsMap)
         try container.encode(.gainDb, gainDb)
+        try container.encode(.muteSoundEnabled, muteSoundEnabled)
+        try container.encode(.muteSoundId, muteSoundId)
     }
 
     required init(from decoder: any Decoder) throws {
@@ -184,5 +190,7 @@ class SettingsAudio: Codable, ObservableObject {
                                                     SettingsAudioOutputToInputChannelsMap.self,
                                                     .init())
         gainDb = container.decode(.gainDb, Float.self, 0.0)
+        muteSoundEnabled = container.decode(.muteSoundEnabled, Bool.self, false)
+        muteSoundId = container.decode(.muteSoundId, UUID?.self, nil)
     }
 }

--- a/Moblin/View/MainView.swift
+++ b/Moblin/View/MainView.swift
@@ -265,13 +265,18 @@ private struct MutedView: View {
 
     var body: some View {
         if level.isMuted() {
-            Image(systemName: "microphone.slash")
-                .font(.system(size: 80))
-                .foregroundStyle(.red)
-                .padding(10)
-                .background(.black.opacity(0.75))
-                .cornerRadius(10)
-                .allowsHitTesting(false)
+            VStack(spacing: 8) {
+                Image(systemName: "microphone.slash")
+                    .font(.system(size: 80))
+                    .foregroundStyle(.red)
+                Text(String(localized: "Mute"))
+                    .font(.headline)
+                    .foregroundStyle(.white)
+            }
+            .padding(20)
+            .background(.black.opacity(0.75))
+            .cornerRadius(10)
+            .allowsHitTesting(false)
         }
     }
 }

--- a/Moblin/View/Settings/Audio/AudioSettingsView.swift
+++ b/Moblin/View/Settings/Audio/AudioSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 private struct MicView: View {
     let model: Model
@@ -145,7 +146,81 @@ struct AudioSettingsView: View {
             } footer: {
                 Text("Mono audio only uses output channel 1. Stereo audio uses both output channels.")
             }
+            Section {
+                Toggle("Mute loop sound", isOn: $audio.muteSoundEnabled)
+                if audio.muteSoundEnabled {
+                    NavigationLink {
+                        MuteSoundSelectorView(
+                            model: model,
+                            soundId: $audio.muteSoundId
+                        )
+                        .environmentObject(model)
+                    } label: {
+                        HStack {
+                            Text("Sound")
+                            Spacer()
+                            GrayTextView(text: getMuteSoundName(model: model, soundId: audio.muteSoundId))
+                        }
+                    }
+                }
+            } header: {
+                Text("Mute feedback")
+            } footer: {
+                Text("Play a looping alert sound while the microphone is muted.")
+            }
+        }
+        .onChange(of: audio.muteSoundEnabled) { _ in
+            model.updateMute()
+        }
+        .onChange(of: audio.muteSoundId) { _ in
+            model.updateMute()
         }
         .navigationTitle("Audio")
+    }
+}
+
+@MainActor
+private func getMuteSoundName(model: Model, soundId: UUID?) -> String {
+    if let soundId {
+        model.getAllAlertSounds().first(where: { $0.id == soundId })?.name ?? String(localized: "-- None --")
+    } else {
+        model.getAllAlertSounds().first?.name ?? String(localized: "Notification 2")
+    }
+}
+
+private struct MuteSoundSelectorView: View {
+    let model: Model
+    @Binding var soundId: UUID?
+    @State private var previewPlayer: AudioPlayer?
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("", selection: $soundId) {
+                    ForEach(model.getAllAlertSounds()) { sound in
+                        HStack {
+                            Text(sound.name)
+                            Spacer()
+                            Button {
+                                guard let url = model.getAlertSoundUrl(soundId: sound.id) else {
+                                    return
+                                }
+                                previewPlayer = try? AudioPlayer(contentsOf: url)
+                                previewPlayer?.play()
+                            } label: {
+                                Image(systemName: "play.fill")
+                            }
+                        }
+                        .tag(sound.id as UUID?)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            }
+        }
+        .onDisappear {
+            previewPlayer = nil
+        }
+        .navigationTitle("Sound")
     }
 }


### PR DESCRIPTION
Adds customizable looping mute audio feedback with a localized visual overlay ("Mute"/"Mudo") in the center of the screen when muted.
Key features:

Plays a customizable sound in an infinite loop while muted, stopping immediately when unmuted.
Users can choose from bundled alerts or import custom audio files directly from their device storage (Mac/iPhone/iPad).
Supported audio formats: MP3, M4A/AAC, WAV, CAF, and AIFF.
Includes a new pre-bundled loop sound option ("Mute loop.mp3") available by default.