### PR TITLE
Sync delay

### DIFF
--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -17295,6 +17295,9 @@
         }
       }
     },
+    "0 ms by default." : {
+
+    },
     "0.0 dB by default, leaving the input level unchanged." : {
       "localizations" : {
         "de" : {
@@ -18346,6 +18349,9 @@
           }
         }
       }
+    },
+    "5 or more milliseconds. 500 ms by default." : {
+
     },
     "5 or more milliseconds. 2000 ms by default." : {
       "localizations" : {
@@ -29747,6 +29753,9 @@
         }
       }
     },
+    "Additional delay introduced by this camera before its stream reaches Moblin." : {
+
+    },
     "Advanced" : {
       "localizations" : {
         "de" : {
@@ -30634,6 +30643,9 @@
           }
         }
       }
+    },
+    "Align visible network sources with built-in cameras and microphones using each source's latency and camera processing delay." : {
+
     },
     "Alignment" : {
       "localizations" : {
@@ -52091,6 +52103,7 @@
       }
     },
     "Builtin audio and video delay" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -53571,6 +53584,12 @@
           }
         }
       }
+    },
+    "Camera processing delay" : {
+
+    },
+    "Camera processing delay is additional delay introduced before the stream reaches Moblin." : {
+
     },
     "Camera switching" : {
       "localizations" : {
@@ -142200,6 +142219,9 @@
           }
         }
       }
+    },
+    "Must be zero or more milliseconds" : {
+
     },
     "Mute" : {
       "localizations" : {
@@ -232761,6 +232783,9 @@
           }
         }
       }
+    },
+    "Synchronize network sources" : {
+
     },
     "System" : {
       "localizations" : {

--- a/Moblin/Media/HaishinKit/Srt/SrtSocketOption.swift
+++ b/Moblin/Media/HaishinKit/Srt/SrtSocketOption.swift
@@ -1,6 +1,17 @@
 import Foundation
 import libsrt
 
+func srtNegotiatedReceiveLatency(socket: SRTSOCKET) -> Double? {
+    var latency: Int32 = 0
+    var size = Int32(MemoryLayout.size(ofValue: latency))
+    guard srt_getsockflag(socket, SRTO_RCVLATENCY, &latency, &size) != SRT_ERROR,
+          latency >= 0
+    else {
+        return nil
+    }
+    return Double(latency) / 1000
+}
+
 private nonisolated(unsafe) let enummapTranstype: [String: Any] = [
     "live": SRTT_LIVE,
     "file": SRTT_FILE,

--- a/Moblin/Media/SrtClient/SrtClient.swift
+++ b/Moblin/Media/SrtClient/SrtClient.swift
@@ -5,7 +5,7 @@ private let srtClientQueue = DispatchQueue(label: "com.eerimoq.moblin.srt-client
                                            qos: .userInteractive)
 
 protocol SrtClientDelegate: AnyObject {
-    func srtClientConnected(cameraId: UUID)
+    func srtClientConnected(cameraId: UUID, latency: Double)
     func srtClientDisconnected(cameraId: UUID)
     func srtClientOnVideoBuffer(cameraId: UUID, _ sampleBuffer: CMSampleBuffer)
     func srtClientOnAudioBuffer(cameraId: UUID, _ sampleBuffer: CMSampleBuffer)
@@ -14,12 +14,12 @@ protocol SrtClientDelegate: AnyObject {
                                      _ audioTargetLatency: Double)
 }
 
-let srtClientLatency = 0.5
 private let reconnectDelay = 5.0
 
 class SrtClient: @unchecked Sendable {
     private let cameraId: UUID
     private let url: URL
+    private let latency: Double
     private weak var delegate: (any SrtClientDelegate)?
     private var running = false
     private var socket: SRTSOCKET = SRT_INVALID_SOCK
@@ -28,9 +28,10 @@ class SrtClient: @unchecked Sendable {
     private var reader: MpegTsReader
     private let softwareDecoding: Bool
 
-    init(cameraId: UUID, url: URL, softwareDecoding: Bool, delegate: any SrtClientDelegate) {
+    init(cameraId: UUID, url: URL, latency: Double, softwareDecoding: Bool, delegate: any SrtClientDelegate) {
         self.cameraId = cameraId
         self.url = url
+        self.latency = latency
         self.softwareDecoding = softwareDecoding
         self.delegate = delegate
         reader = MpegTsReader(
@@ -38,7 +39,7 @@ class SrtClient: @unchecked Sendable {
             decoderQueue: srtClientQueue,
             timecodesEnabled: false,
             softwareDecoding: softwareDecoding,
-            targetLatency: srtClientLatency
+            targetLatency: latency
         )
         reader.delegate = self
     }
@@ -124,15 +125,16 @@ class SrtClient: @unchecked Sendable {
         if !postFailures.isEmpty {
             logger.info("srt-client: \(cameraId): Failed to set post-bind options: \(postFailures).")
         }
+        let negotiatedLatency = srtNegotiatedReceiveLatency(socket: socket) ?? 0.5
         reader = MpegTsReader(
             name: "srt-client",
             decoderQueue: srtClientQueue,
             timecodesEnabled: false,
             softwareDecoding: softwareDecoding,
-            targetLatency: srtClientLatency
+            targetLatency: negotiatedLatency
         )
         reader.delegate = self
-        delegate?.srtClientConnected(cameraId: cameraId)
+        delegate?.srtClientConnected(cameraId: cameraId, latency: negotiatedLatency)
         receive(socket: socket)
         delegate?.srtClientDisconnected(cameraId: cameraId)
         srtClientQueue.async {

--- a/Moblin/Media/Srtla/Server/SrtServer.swift
+++ b/Moblin/Media/Srtla/Server/SrtServer.swift
@@ -61,11 +61,13 @@ class SrtServer: @unchecked Sendable {
             logger.info("srt-server: \(port): Accepted client \(stream.name).")
             let cameraId = stream.id
             let name = stream.camera()
+            let latency = srtNegotiatedReceiveLatency(socket: clientSocket) ?? 0.5
             startBlockingThread(name: "com.eerimoq.Moblin.SrtClient") {
                 srtlaServer.connectedStreamIds.mutate { $0.append(streamId) }
-                srtlaServer.clientConnected(cameraId: cameraId, name: name)
+                srtlaServer.clientConnected(cameraId: cameraId, name: name, latency: latency)
                 SrtServerClient(server: self,
                                 cameraId: cameraId,
+                                latency: latency,
                                 timecodesEnabled: self.timecodesEnabled,
                                 softwareDecoding: self.softwareDecoding)
                     .run(clientSocket: clientSocket)

--- a/Moblin/Media/Srtla/Server/SrtServerClient.swift
+++ b/Moblin/Media/Srtla/Server/SrtServerClient.swift
@@ -1,21 +1,24 @@
 import AVFoundation
 import libsrt
 
-let srtServerClientLatency = 0.5
-
 class SrtServerClient {
     private weak var server: SrtServer?
     private let cameraId: UUID
     private let reader: MpegTsReader
 
-    init(server: SrtServer, cameraId: UUID, timecodesEnabled: Bool, softwareDecoding: Bool) {
+    init(server: SrtServer,
+         cameraId: UUID,
+         latency: Double,
+         timecodesEnabled: Bool,
+         softwareDecoding: Bool)
+    {
         self.server = server
         self.cameraId = cameraId
         reader = MpegTsReader(name: "srt-server",
                               decoderQueue: srtlaServerQueue,
                               timecodesEnabled: timecodesEnabled,
                               softwareDecoding: softwareDecoding,
-                              targetLatency: srtServerClientLatency)
+                              targetLatency: latency)
         reader.delegate = self
     }
 

--- a/Moblin/Media/Srtla/Server/SrtlaServer.swift
+++ b/Moblin/Media/Srtla/Server/SrtlaServer.swift
@@ -11,7 +11,7 @@ let srtlaServerQueue = DispatchQueue(label: "com.eerimoq.srtla-server", qos: .us
 private let periodicTimerTimeout = 3.0
 
 protocol SrtlaServerDelegate: AnyObject {
-    func srtlaServerOnClientStart(cameraId: UUID, name: String)
+    func srtlaServerOnClientStart(cameraId: UUID, name: String, latency: Double)
     func srtlaServerOnClientStop(cameraId: UUID, name: String)
     func srtlaServerOnVideoBuffer(cameraId: UUID, sampleBuffer: CMSampleBuffer)
     func srtlaServerOnAudioBuffer(cameraId: UUID, sampleBuffer: CMSampleBuffer)
@@ -92,9 +92,9 @@ class SrtlaServer: @unchecked Sendable {
         numberOfClients.value
     }
 
-    func clientConnected(cameraId: UUID, name: String) {
+    func clientConnected(cameraId: UUID, name: String, latency: Double) {
         numberOfClients.mutate { $0 += 1 }
-        delegate.srtlaServerOnClientStart(cameraId: cameraId, name: name)
+        delegate.srtlaServerOnClientStart(cameraId: cameraId, name: name, latency: latency)
     }
 
     func clientDisconnected(cameraId: UUID, name: String) {

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -428,6 +428,11 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     }
 
     var activeBufferedVideoIds: Set<UUID> = []
+    var sceneSynchronizationBuiltinDelay: Double?
+    var sceneSynchronizationAdditionalDelays: [UUID: Double] = [:]
+    var networkSourceTargetLatencies: [UUID: (video: Double, audio: Double)] = [:]
+    var networkSourceNegotiatedLatencies: [UUID: Double] = [:]
+    var networkSourceConnectedIds: Set<UUID> = []
     var wiFiAwareSenderTask: Task<Void, any Error>?
     var wiFiAwareReceiverTask: Task<Void, any Error>?
     nonisolated(unsafe) let youTube = YouTube()
@@ -2876,13 +2881,13 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
             : [])
         let params = VideoUnitAttachParams(
             devices: devices,
-            builtinDelay: database.debug.builtinAudioAndVideoDelay,
+            builtinDelay: sceneSynchronizationPlan(scene: scene).builtinDelay,
             cameraPreviewLayers: cameraPreviewView.previewLayers,
             showCameraPreview: showCameraPreview,
             externalDisplayPreview: externalDisplayPreview,
             bufferedVideo: nil,
             preferredVideoStabilizationMode: getVideoStabilizationMode(scene: scene),
-            ignoreFramesAfterAttachSeconds: getIgnoreFramesAfterAttachSeconds(),
+            ignoreFramesAfterAttachSeconds: getIgnoreFramesAfterAttachSeconds(scene: scene),
             fillFrame: getFillFrame(scene: scene),
             isLandscapeStreamAndPortraitUi: isLandscapeStreamAndPortraitUi(),
             forceSceneTransition: database.forceSceneSwitchTransition,
@@ -2916,8 +2921,8 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         updateBackZoomPresets()
     }
 
-    private func getIgnoreFramesAfterAttachSeconds() -> Double {
-        Double(database.debug.cameraSwitchRemoveBlackish) + database.debug.builtinAudioAndVideoDelay
+    private func getIgnoreFramesAfterAttachSeconds(scene: SettingsScene) -> Double {
+        Double(database.debug.cameraSwitchRemoveBlackish) + sceneSynchronizationPlan(scene: scene).builtinDelay
     }
 
     private func getIgnoreFramesAfterAttachSecondsReplaceCamera() -> Double {
@@ -2937,7 +2942,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         cameraPreviewView.setDevices(ids: [])
         media.attachBufferedCamera(
             devices: getBuiltinCameraDevices(scene: scene, sceneDevice: nil),
-            builtinDelay: database.debug.builtinAudioAndVideoDelay,
+            builtinDelay: sceneSynchronizationPlan(scene: scene).builtinDelay,
             cameraPreviewLayers: cameraPreviewView.previewLayers,
             showCameraPreview: updateShowCameraPreview(),
             externalDisplayPreview: externalDisplayPreview,

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -2922,7 +2922,8 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     }
 
     private func getIgnoreFramesAfterAttachSeconds(scene: SettingsScene) -> Double {
-        Double(database.debug.cameraSwitchRemoveBlackish) + sceneSynchronizationPlan(scene: scene).builtinDelay
+        Double(database.debug.cameraSwitchRemoveBlackish) + sceneSynchronizationPlan(scene: scene)
+            .builtinDelay
     }
 
     private func getIgnoreFramesAfterAttachSecondsReplaceCamera() -> Double {

--- a/Moblin/Various/Model/ModelAudio.swift
+++ b/Moblin/Various/Model/ModelAudio.swift
@@ -64,7 +64,7 @@ extension Model {
     func reloadAudioSession() {
         teardownAudioSession()
         setupAudioSession()
-        media.attachDefaultAudioDevice(builtinDelay: database.debug.builtinAudioAndVideoDelay)
+        media.attachDefaultAudioDevice(builtinDelay: currentSceneSynchronizationBuiltinDelay())
     }
 
     func setInputGainIfSupported(inputGain: Float) {
@@ -244,7 +244,7 @@ extension Model {
             try? setBuiltInMicAudioMode(dataSource: dataSource, preferStereoMic: preferStereoMic)
             try? session.setInputDataSource(dataSource)
         }
-        media.attachDefaultAudioDevice(builtinDelay: database.debug.builtinAudioAndVideoDelay)
+        media.attachDefaultAudioDevice(builtinDelay: currentSceneSynchronizationBuiltinDelay())
         remoteControlStateChanged(state: RemoteControlAssistantStreamerState(mic: mic.id))
     }
 

--- a/Moblin/Various/Model/ModelRistServer.swift
+++ b/Moblin/Various/Model/ModelRistServer.swift
@@ -78,8 +78,9 @@ extension Model: @preconcurrency RistServerDelegate {
         guard let cameraId = getRistStream(virtualDestinationPort: virtualDestinationPort)?.id else {
             return
         }
-        media.setBufferedVideoTargetLatency(cameraId: cameraId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: cameraId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: cameraId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 
     private func ristServerOnConnectedInternal(virtualDestinationPort: UInt16) {
@@ -91,6 +92,7 @@ extension Model: @preconcurrency RistServerDelegate {
         let latency = stream.latencySeconds()
         media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
         media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+        setBufferedTargetLatencies(cameraId: stream.id, videoLatency: latency, audioLatency: latency)
     }
 
     private func ristServerOnDisconnectedInternal(virtualDestinationPort: UInt16, reason _: String) {

--- a/Moblin/Various/Model/ModelRtmpServer.swift
+++ b/Moblin/Various/Model/ModelRtmpServer.swift
@@ -44,6 +44,9 @@ extension Model {
                                         name: camera,
                                         latency: latency,
                                         trackDrift: stream.trackDrift)
+            self.setBufferedTargetLatencies(cameraId: stream.id,
+                                            videoLatency: latency,
+                                            audioLatency: latency)
             self.markDjiIsStreamingIfNeeded(rtmpServerStreamId: stream.id)
         }
     }
@@ -127,7 +130,8 @@ extension Model: @preconcurrency RtmpServerDelegate {
         _ videoTargetLatency: Double,
         _ audioTargetLatency: Double
     ) {
-        media.setBufferedVideoTargetLatency(cameraId: cameraId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: cameraId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: cameraId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 }

--- a/Moblin/Various/Model/ModelRtspClient.swift
+++ b/Moblin/Various/Model/ModelRtspClient.swift
@@ -50,7 +50,9 @@ extension Model {
         }
         let camera = stream.camera()
         makeToast(title: String(localized: "\(camera) connected"))
-        media.addBufferedVideo(cameraId: cameraId, name: camera, latency: stream.latencySeconds())
+        let latency = stream.latencySeconds()
+        media.addBufferedVideo(cameraId: cameraId, name: camera, latency: latency)
+        setBufferedTargetLatencies(cameraId: cameraId, videoLatency: latency, audioLatency: latency)
     }
 
     func rtspClientDisconnectedInternal(cameraId: UUID) {

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -37,6 +37,35 @@ struct WidgetInScene: Identifiable {
 
 let defaultScoreboardSize = 18.52
 
+struct NetworkSourceDelay: Equatable {
+    let id: UUID
+    let latency: Double
+    let intrinsicDelay: Double
+
+    var effectiveDelay: Double {
+        latency + intrinsicDelay
+    }
+}
+
+struct SceneSynchronizationPlan: Equatable {
+    let builtinDelay: Double
+    let additionalDelays: [UUID: Double]
+
+    static func make(sources: [NetworkSourceDelay]) -> Self {
+        let sourcesById = Dictionary(sources.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+        let uniqueSources = Array(sourcesById.values)
+        guard let builtinDelay = uniqueSources.map(\.effectiveDelay).max() else {
+            return .init(builtinDelay: 0, additionalDelays: [:])
+        }
+        return .init(
+            builtinDelay: builtinDelay,
+            additionalDelays: Dictionary(uniqueKeysWithValues: uniqueSources.map {
+                ($0.id, max(0, builtinDelay - $0.effectiveDelay))
+            })
+        )
+    }
+}
+
 extension Model {
     func getTextEffects(id: UUID) -> [TextEffect] {
         var effects: [TextEffect] = []
@@ -1042,8 +1071,15 @@ extension Model {
             }
         }
         media.setSpeechToText(enabled: needsSpeechToText)
-        if attachCamera {
+        let synchronizationPlan = sceneSynchronizationPlan(scene: scene)
+        applySceneSynchronizationPlan(synchronizationPlan)
+        let reattachBuiltinMedia = synchronizationPlan.builtinDelay != sceneSynchronizationBuiltinDelay
+        sceneSynchronizationBuiltinDelay = synchronizationPlan.builtinDelay
+        if attachCamera || reattachBuiltinMedia {
             attachSingleLayout(scene: scene)
+            if reattachBuiltinMedia, mic.current.isBuiltin() {
+                media.attachDefaultAudioDevice(builtinDelay: synchronizationPlan.builtinDelay)
+            }
         } else {
             media.usePendingAfterAttachEffects()
         }
@@ -1599,6 +1635,168 @@ extension Model {
             getBuiltinCameraDevicesInScene(scene: scene,
                                            devices: &devices,
                                            addedSceneIds: &addedSceneIds)
+        }
+    }
+
+    func sceneSynchronizationPlan(scene: SettingsScene) -> SceneSynchronizationPlan {
+        guard scene.networkSourceSynchronizationEnabled else {
+            return .init(builtinDelay: 0, additionalDelays: [:])
+        }
+        let sourceIds = getVisibleNetworkSourceIds(scene: scene)
+        return .make(sources: sourceIds.compactMap(networkSourceDelay(id:)))
+    }
+
+    func currentSceneSynchronizationBuiltinDelay() -> Double {
+        guard let scene = getSelectedScene() else {
+            return 0
+        }
+        return sceneSynchronizationPlan(scene: scene).builtinDelay
+    }
+
+    func setBufferedTargetLatencies(
+        cameraId: UUID,
+        videoLatency: Double,
+        audioLatency: Double
+    ) {
+        networkSourceTargetLatencies[cameraId] = (videoLatency, audioLatency)
+        let plan = getSelectedScene().map { sceneSynchronizationPlan(scene: $0) }
+        let additionalDelay = plan?.additionalDelays[cameraId] ?? 0
+        media.setBufferedVideoTargetLatency(cameraId: cameraId, latency: videoLatency + additionalDelay)
+        media.setBufferedAudioTargetLatency(cameraId: cameraId, latency: audioLatency + additionalDelay)
+    }
+
+    private func applySceneSynchronizationPlan(_ plan: SceneSynchronizationPlan) {
+        let sourceIds = Set(plan.additionalDelays.keys)
+            .union(sceneSynchronizationAdditionalDelays.keys)
+        for id in sourceIds {
+            guard let source = networkSourceDelay(id: id) else {
+                continue
+            }
+            let targetLatencies = networkSourceTargetLatencies[id] ?? (source.latency, source.latency)
+            let additionalDelay = plan.additionalDelays[id] ?? 0
+            media.setBufferedVideoTargetLatency(cameraId: id, latency: targetLatencies.video + additionalDelay)
+            media.setBufferedAudioTargetLatency(cameraId: id, latency: targetLatencies.audio + additionalDelay)
+        }
+        sceneSynchronizationAdditionalDelays = plan.additionalDelays
+    }
+
+    private func networkSourceDelay(id: UUID) -> NetworkSourceDelay? {
+        if let stream = getRtmpStream(id: id) {
+            return makeNetworkSourceDelay(id: id,
+                                          latency: stream.latencySeconds(),
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getSrtlaStream(id: id) {
+            guard networkSourceConnectedIds.contains(id),
+                  let latency = networkSourceNegotiatedLatencies[id]
+            else {
+                return nil
+            }
+            return makeNetworkSourceDelay(id: id,
+                                          latency: latency,
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getSrtClientStream(id: id) {
+            guard networkSourceConnectedIds.contains(id),
+                  let latency = networkSourceNegotiatedLatencies[id]
+            else {
+                return nil
+            }
+            return makeNetworkSourceDelay(id: id,
+                                          latency: latency,
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getRistStream(id: id) {
+            return makeNetworkSourceDelay(id: id,
+                                          latency: stream.latencySeconds(),
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getRtspStream(id: id) {
+            return makeNetworkSourceDelay(id: id,
+                                          latency: stream.latencySeconds(),
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getWhipStream(id: id) {
+            return makeNetworkSourceDelay(id: id,
+                                          latency: stream.latencySeconds(),
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        if let stream = getWhepStream(id: id) {
+            return makeNetworkSourceDelay(id: id,
+                                          latency: stream.latencySeconds(),
+                                          intrinsicDelay: stream.intrinsicDelaySeconds())
+        }
+        return nil
+    }
+
+    private func makeNetworkSourceDelay(id: UUID, latency: Double, intrinsicDelay: Double) -> NetworkSourceDelay {
+        .init(id: id, latency: max(0, latency), intrinsicDelay: max(0, intrinsicDelay))
+    }
+
+    private func getVisibleNetworkSourceIds(scene: SettingsScene) -> Set<UUID> {
+        var ids: Set<UUID> = []
+        var visitedSceneIds: Set<UUID> = []
+        getVisibleNetworkSourceIds(scene: scene,
+                                   includeSceneVideoSource: true,
+                                   ids: &ids,
+                                   visitedSceneIds: &visitedSceneIds)
+        return ids
+    }
+
+    private func getVisibleNetworkSourceIds(
+        scene: SettingsScene,
+        includeSceneVideoSource: Bool,
+        ids: inout Set<UUID>,
+        visitedSceneIds: inout Set<UUID>
+    ) {
+        guard visitedSceneIds.insert(scene.id).inserted else {
+            return
+        }
+        if includeSceneVideoSource {
+            addVisibleNetworkSourceId(videoSource: scene.videoSource, ids: &ids)
+        }
+        for sceneWidget in scene.widgets {
+            guard let widget = findWidget(id: sceneWidget.widgetId), widget.enabled else {
+                continue
+            }
+            switch widget.type {
+            case .videoSource:
+                addVisibleNetworkSourceId(videoSource: widget.videoSource.videoSource, ids: &ids)
+            case .vTuber:
+                addVisibleNetworkSourceId(videoSource: widget.vTuber.videoSource, ids: &ids)
+            case .pngTuber:
+                addVisibleNetworkSourceId(videoSource: widget.pngTuber.videoSource, ids: &ids)
+            case .scene:
+                if let nestedScene = database.scenes.first(where: { $0.id == widget.scene.sceneId }) {
+                    getVisibleNetworkSourceIds(scene: nestedScene,
+                                               includeSceneVideoSource: false,
+                                               ids: &ids,
+                                               visitedSceneIds: &visitedSceneIds)
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    private func addVisibleNetworkSourceId(videoSource: SettingsVideoSource, ids: inout Set<UUID>) {
+        switch videoSource.cameraPosition {
+        case .rtmp:
+            ids.insert(videoSource.rtmpCameraId)
+        case .srtla:
+            ids.insert(videoSource.srtlaCameraId)
+        case .srtClient:
+            ids.insert(videoSource.srtClientCameraId)
+        case .rist:
+            ids.insert(videoSource.ristCameraId)
+        case .rtsp:
+            ids.insert(videoSource.rtspCameraId)
+        case .whip:
+            ids.insert(videoSource.whipCameraId)
+        case .whep:
+            ids.insert(videoSource.whepCameraId)
+        default:
+            break
         }
     }
 

--- a/Moblin/Various/Model/ModelScene.swift
+++ b/Moblin/Various/Model/ModelScene.swift
@@ -1674,8 +1674,14 @@ extension Model {
             }
             let targetLatencies = networkSourceTargetLatencies[id] ?? (source.latency, source.latency)
             let additionalDelay = plan.additionalDelays[id] ?? 0
-            media.setBufferedVideoTargetLatency(cameraId: id, latency: targetLatencies.video + additionalDelay)
-            media.setBufferedAudioTargetLatency(cameraId: id, latency: targetLatencies.audio + additionalDelay)
+            media.setBufferedVideoTargetLatency(
+                cameraId: id,
+                latency: targetLatencies.video + additionalDelay
+            )
+            media.setBufferedAudioTargetLatency(
+                cameraId: id,
+                latency: targetLatencies.audio + additionalDelay
+            )
         }
         sceneSynchronizationAdditionalDelays = plan.additionalDelays
     }
@@ -1729,7 +1735,9 @@ extension Model {
         return nil
     }
 
-    private func makeNetworkSourceDelay(id: UUID, latency: Double, intrinsicDelay: Double) -> NetworkSourceDelay {
+    private func makeNetworkSourceDelay(id: UUID, latency: Double,
+                                        intrinsicDelay: Double) -> NetworkSourceDelay
+    {
         .init(id: id, latency: max(0, latency), intrinsicDelay: max(0, intrinsicDelay))
     }
 

--- a/Moblin/Various/Model/ModelSrtClient.swift
+++ b/Moblin/Various/Model/ModelSrtClient.swift
@@ -32,6 +32,7 @@ extension Model {
             }
             let client = SrtClient(cameraId: stream.id,
                                    url: url,
+                                   latency: stream.latencySeconds(),
                                    softwareDecoding: database.ingestsSoftwareVideoDecoding,
                                    delegate: self)
             client.start()
@@ -46,14 +47,22 @@ extension Model {
         ingests.srt = []
     }
 
-    private func srtClientConnectedInternal(cameraId: UUID) {
+    private func srtClientConnectedInternal(cameraId: UUID, latency: Double) {
         guard let stream = getSrtClientStream(id: cameraId) else {
             return
         }
         let camera = stream.camera()
         makeToast(title: String(localized: "\(camera) connected"))
-        media.addBufferedVideo(cameraId: cameraId, name: camera, latency: srtClientLatency)
-        media.addBufferedAudio(cameraId: cameraId, name: camera, latency: srtClientLatency)
+        let previousLatency = networkSourceNegotiatedLatencies[cameraId]
+        let previousBuiltinDelay = currentSceneSynchronizationBuiltinDelay()
+        networkSourceNegotiatedLatencies[cameraId] = latency
+        networkSourceConnectedIds.insert(cameraId)
+        media.addBufferedVideo(cameraId: cameraId, name: camera, latency: latency)
+        media.addBufferedAudio(cameraId: cameraId, name: camera, latency: latency)
+        setBufferedTargetLatencies(cameraId: cameraId, videoLatency: latency, audioLatency: latency)
+        if previousLatency != latency || previousBuiltinDelay != currentSceneSynchronizationBuiltinDelay() {
+            sceneUpdated(updateRemoteScene: false)
+        }
     }
 
     private func srtClientDisconnectedInternal(cameraId: UUID) {
@@ -63,13 +72,14 @@ extension Model {
         makeToast(title: String(localized: "\(stream.camera()) disconnected"))
         media.removeBufferedVideo(cameraId: cameraId)
         media.removeBufferedAudio(cameraId: cameraId)
+        networkSourceConnectedIds.remove(cameraId)
     }
 }
 
 extension Model: @preconcurrency SrtClientDelegate {
-    func srtClientConnected(cameraId: UUID) {
+    func srtClientConnected(cameraId: UUID, latency: Double) {
         DispatchQueue.main.async {
-            self.srtClientConnectedInternal(cameraId: cameraId)
+            self.srtClientConnectedInternal(cameraId: cameraId, latency: latency)
         }
     }
 
@@ -92,7 +102,8 @@ extension Model: @preconcurrency SrtClientDelegate {
         _ videoTargetLatency: Double,
         _ audioTargetLatency: Double
     ) {
-        media.setBufferedVideoTargetLatency(cameraId: cameraId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: cameraId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: cameraId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 }

--- a/Moblin/Various/Model/ModelSrtlaServer.swift
+++ b/Moblin/Various/Model/ModelSrtlaServer.swift
@@ -46,9 +46,9 @@ extension Model {
 }
 
 extension Model: @preconcurrency SrtlaServerDelegate {
-    func srtlaServerOnClientStart(cameraId: UUID, name: String) {
+    func srtlaServerOnClientStart(cameraId: UUID, name: String, latency: Double) {
         DispatchQueue.main.async {
-            self.srtlaServerOnClientStartInternal(cameraId: cameraId, name: name)
+            self.srtlaServerOnClientStartInternal(cameraId: cameraId, name: name, latency: latency)
         }
     }
 
@@ -58,16 +58,28 @@ extension Model: @preconcurrency SrtlaServerDelegate {
         }
     }
 
-    private func srtlaServerOnClientStartInternal(cameraId: UUID, name: String) {
+    private func srtlaServerOnClientStartInternal(cameraId: UUID, name: String, latency: Double) {
+        guard let stream = getSrtlaStream(id: cameraId) else {
+            return
+        }
         makeToast(title: String(localized: "\(name) connected"))
-        media.addBufferedVideo(cameraId: cameraId, name: name, latency: srtServerClientLatency)
-        media.addBufferedAudio(cameraId: cameraId, name: name, latency: srtServerClientLatency)
+        let previousLatency = networkSourceNegotiatedLatencies[cameraId]
+        let previousBuiltinDelay = currentSceneSynchronizationBuiltinDelay()
+        networkSourceNegotiatedLatencies[cameraId] = latency
+        networkSourceConnectedIds.insert(cameraId)
+        media.addBufferedVideo(cameraId: cameraId, name: name, latency: latency)
+        media.addBufferedAudio(cameraId: cameraId, name: name, latency: latency)
+        setBufferedTargetLatencies(cameraId: cameraId, videoLatency: latency, audioLatency: latency)
+        if previousLatency != latency || previousBuiltinDelay != currentSceneSynchronizationBuiltinDelay() {
+            sceneUpdated(updateRemoteScene: false)
+        }
     }
 
     private func srtlaServerOnClientStopInternal(cameraId: UUID, name: String) {
         makeToast(title: String(localized: "\(name) disconnected"))
         media.removeBufferedVideo(cameraId: cameraId)
         media.removeBufferedAudio(cameraId: cameraId)
+        networkSourceConnectedIds.remove(cameraId)
     }
 
     func srtlaServerOnAudioBuffer(cameraId: UUID, sampleBuffer: CMSampleBuffer) {
@@ -83,7 +95,8 @@ extension Model: @preconcurrency SrtlaServerDelegate {
         _ videoTargetLatency: Double,
         _ audioTargetLatency: Double
     ) {
-        media.setBufferedVideoTargetLatency(cameraId: cameraId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: cameraId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: cameraId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 }

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -373,7 +373,7 @@ extension Model {
             proto: stream.getProtocol(),
             portrait: stream.portrait,
             timecodesEnabled: isTimecodesEnabled(),
-            builtinAudioDelay: database.debug.builtinAudioAndVideoDelay,
+            builtinAudioDelay: currentSceneSynchronizationBuiltinDelay(),
             destinations: stream.multiStreaming.destinations,
             srtImplementation: stream.srt.implementation,
             limitAdaptiveBitrateByTransportBitrate: stream.rateControl != .cbr

--- a/Moblin/Various/Model/ModelWhepClient.swift
+++ b/Moblin/Various/Model/ModelWhepClient.swift
@@ -64,6 +64,9 @@ extension Model: @preconcurrency WhepClientDelegate {
             let latency = stream.latencySeconds()
             self.media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
             self.media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+            self.setBufferedTargetLatencies(cameraId: stream.id,
+                                            videoLatency: latency,
+                                            audioLatency: latency)
         }
     }
 
@@ -93,7 +96,8 @@ extension Model: @preconcurrency WhepClientDelegate {
                                       _ videoTargetLatency: Double,
                                       _ audioTargetLatency: Double)
     {
-        media.setBufferedVideoTargetLatency(cameraId: streamId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: streamId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: streamId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 }

--- a/Moblin/Various/Model/ModelWhipServer.swift
+++ b/Moblin/Various/Model/ModelWhipServer.swift
@@ -62,6 +62,9 @@ extension Model {
             let latency = stream.latencySeconds()
             self.media.addBufferedVideo(cameraId: stream.id, name: camera, latency: latency)
             self.media.addBufferedAudio(cameraId: stream.id, name: camera, latency: latency)
+            self.setBufferedTargetLatencies(cameraId: stream.id,
+                                            videoLatency: latency,
+                                            audioLatency: latency)
         }
     }
 
@@ -86,8 +89,9 @@ extension Model {
                                             _ videoTargetLatency: Double,
                                             _ audioTargetLatency: Double)
     {
-        media.setBufferedVideoTargetLatency(cameraId: streamId, latency: videoTargetLatency)
-        media.setBufferedAudioTargetLatency(cameraId: streamId, latency: audioTargetLatency)
+        setBufferedTargetLatencies(cameraId: streamId,
+                                   videoLatency: videoTargetLatency,
+                                   audioLatency: audioTargetLatency)
     }
 
     func stopWhipServer() {

--- a/Moblin/Various/Settings/SettingsDebug.swift
+++ b/Moblin/Various/Settings/SettingsDebug.swift
@@ -15,7 +15,6 @@ let pixelFormatTypes = [
 ]
 
 class SettingsDebug: Codable, ObservableObject {
-    static let builtinAudioAndVideoDelayDefault: Double = 0.07
     var logLevel: SettingsLogLevel = .error
     @Published var logFilter: String = ""
     @Published var debugLogging: Bool = false
@@ -43,8 +42,6 @@ class SettingsDebug: Codable, ObservableObject {
     var videoSourceWidgetTrackFace: Bool = false
     var replay: Bool = false
     var recordSegmentLength: Double = 5.0
-    @Published var builtinAudioAndVideoDelay: Double = builtinAudioAndVideoDelayDefault
-    var builtinAudioAndVideoDelay70msMigrated: Bool = false
     @Published var cameraManMoveVertically: Bool = false
     @Published var cameraManSpeed: Double = 1.0
     @Published var cameraManAlwaysMove: Bool = false
@@ -85,10 +82,8 @@ class SettingsDebug: Codable, ObservableObject {
         case srtlaBatchSendEnabled
         case replay
         case recordSegmentLength
-        case builtinAudioAndVideoDelay
         case overrideSceneMic
         case autoLowPowerMode
-        case builtinAudioAndVideoDelay70msMigrated
         case cameraManMoveVertically
         case cameraManSpeed
         case cameraManAlwaysMove
@@ -126,8 +121,6 @@ class SettingsDebug: Codable, ObservableObject {
         try container.encode(.videoSourceWidgetTrackFace, videoSourceWidgetTrackFace)
         try container.encode(.replay, replay)
         try container.encode(.recordSegmentLength, recordSegmentLength)
-        try container.encode(.builtinAudioAndVideoDelay, builtinAudioAndVideoDelay)
-        try container.encode(.builtinAudioAndVideoDelay70msMigrated, builtinAudioAndVideoDelay70msMigrated)
         try container.encode(.cameraManMoveVertically, cameraManMoveVertically)
         try container.encode(.cameraManSpeed, cameraManSpeed)
         try container.encode(.cameraManAlwaysMove, cameraManAlwaysMove)
@@ -171,16 +164,6 @@ class SettingsDebug: Codable, ObservableObject {
         videoSourceWidgetTrackFace = container.decode(.videoSourceWidgetTrackFace, Bool.self, false)
         replay = container.decode(.replay, Bool.self, false)
         recordSegmentLength = container.decode(.recordSegmentLength, Double.self, 5.0)
-        builtinAudioAndVideoDelay = container.decode(.builtinAudioAndVideoDelay,
-                                                     Double.self,
-                                                     Self.builtinAudioAndVideoDelayDefault)
-        builtinAudioAndVideoDelay70msMigrated = container.decode(.builtinAudioAndVideoDelay70msMigrated,
-                                                                 Bool.self,
-                                                                 false)
-        if !builtinAudioAndVideoDelay70msMigrated, builtinAudioAndVideoDelay == 0 {
-            builtinAudioAndVideoDelay = Self.builtinAudioAndVideoDelayDefault
-        }
-        builtinAudioAndVideoDelay70msMigrated = true
         cameraManMoveVertically = container.decode(.cameraManMoveVertically, Bool.self, false)
         cameraManSpeed = container.decode(.cameraManSpeed, Double.self, 1.0)
         cameraManAlwaysMove = container.decode(.cameraManAlwaysMove, Bool.self, false)

--- a/Moblin/Various/Settings/SettingsIngests.swift
+++ b/Moblin/Various/Settings/SettingsIngests.swift
@@ -8,6 +8,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var streamKey: String = ""
     @Published var latency: Int32 = defaultRtmpLatency
+    @Published var intrinsicDelay: Int32 = 0
     @Published var trackDrift: Bool = true
 
     enum CodingKeys: CodingKey {
@@ -15,6 +16,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         case name
         case streamKey
         case latency
+        case intrinsicDelay
         case trackDrift
     }
 
@@ -24,6 +26,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.streamKey, streamKey)
         try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
         try container.encode(.trackDrift, trackDrift)
     }
 
@@ -35,6 +38,7 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         streamKey = container.decode(.streamKey, String.self, "")
         latency = container.decode(.latency, Int32.self, defaultRtmpLatency)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
         trackDrift = container.decode(.trackDrift, Bool.self, true)
     }
 
@@ -46,12 +50,17 @@ class SettingsRtmpServerStream: Codable, Identifiable, ObservableObject, Named {
         Double(latency) / 1000
     }
 
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
+    }
+
     func clone() -> SettingsRtmpServerStream {
         let new = SettingsRtmpServerStream()
         new.id = id
         new.name = name
         new.streamKey = streamKey
         new.latency = latency
+        new.intrinsicDelay = intrinsicDelay
         new.trackDrift = trackDrift
         return new
     }
@@ -100,11 +109,15 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
     var id: UUID = .init()
     @Published var name: String = baseName
     @Published var streamId: String = ""
+    @Published var latency: Int32 = 500
+    @Published var intrinsicDelay: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
         case name
         case streamId
+        case latency
+        case intrinsicDelay
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -112,6 +125,8 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         try container.encode(.id, id)
         try container.encode(.name, name)
         try container.encode(.streamId, streamId)
+        try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
     }
 
     init() {}
@@ -121,10 +136,20 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         id = container.decode(.id, UUID.self, .init())
         name = container.decode(.name, String.self, Self.baseName)
         streamId = container.decode(.streamId, String.self, "")
+        latency = container.decode(.latency, Int32.self, 500)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
     }
 
     func camera() -> String {
         srtlaCamera(name: name)
+    }
+
+    func latencySeconds() -> Double {
+        Double(latency) / 1000
+    }
+
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
     }
 
     func clone() -> SettingsSrtlaServerStream {
@@ -132,6 +157,8 @@ class SettingsSrtlaServerStream: Codable, Identifiable, ObservableObject, Named 
         new.id = id
         new.name = name
         new.streamId = streamId
+        new.latency = latency
+        new.intrinsicDelay = intrinsicDelay
         return new
     }
 }
@@ -189,12 +216,16 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var url: String = ""
     @Published var enabled: Bool = false
+    @Published var latency: Int32 = 500
+    @Published var intrinsicDelay: Int32 = 0
 
     enum CodingKeys: CodingKey {
         case id
         case name
         case url
         case enabled
+        case latency
+        case intrinsicDelay
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -203,6 +234,8 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.url, url)
         try container.encode(.enabled, enabled)
+        try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
     }
 
     init() {}
@@ -213,10 +246,20 @@ class SettingsSrtClientStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         url = container.decode(.url, String.self, "")
         enabled = container.decode(.enabled, Bool.self, false)
+        latency = container.decode(.latency, Int32.self, 500)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
     }
 
     func camera() -> String {
         srtClientCamera(name: name)
+    }
+
+    func latencySeconds() -> Double {
+        Double(latency) / 1000
+    }
+
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
     }
 }
 
@@ -246,6 +289,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var virtualDestinationPort: UInt16 = 1
     @Published var latency: Int32 = 2000
+    @Published var intrinsicDelay: Int32 = 0
     var connected: Bool = false
 
     enum CodingKeys: CodingKey {
@@ -253,6 +297,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         case name
         case virtualDestinationPort
         case latency
+        case intrinsicDelay
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -261,6 +306,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.virtualDestinationPort, virtualDestinationPort)
         try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
     }
 
     init() {}
@@ -271,10 +317,15 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         virtualDestinationPort = container.decode(.virtualDestinationPort, UInt16.self, 1)
         latency = container.decode(.latency, Int32.self, 2000)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
     }
 
     func latencySeconds() -> Double {
         Double(latency) / 1000
+    }
+
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
     }
 
     func clone() -> SettingsRistServerStream {
@@ -282,6 +333,7 @@ class SettingsRistServerStream: Codable, Identifiable, ObservableObject, Named {
         new.name = name
         new.virtualDestinationPort = virtualDestinationPort
         new.latency = latency
+        new.intrinsicDelay = intrinsicDelay
         return new
     }
 
@@ -347,6 +399,7 @@ class SettingsRtspClientStream: Codable, Identifiable, ObservableObject, Named {
     @Published var url: String = ""
     @Published var enabled: Bool = false
     @Published var latency: Int32 = 2000
+    @Published var intrinsicDelay: Int32 = 0
     @Published var transport: SettingsRtspTransport = .rtpRtspTcp
 
     enum CodingKeys: CodingKey {
@@ -355,11 +408,16 @@ class SettingsRtspClientStream: Codable, Identifiable, ObservableObject, Named {
         case url
         case enabled
         case latency
+        case intrinsicDelay
         case transport
     }
 
     func latencySeconds() -> Double {
         Double(latency) / 1000
+    }
+
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -369,6 +427,7 @@ class SettingsRtspClientStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.url, url)
         try container.encode(.enabled, enabled)
         try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
         try container.encode(.transport, transport)
     }
 
@@ -381,6 +440,7 @@ class SettingsRtspClientStream: Codable, Identifiable, ObservableObject, Named {
         url = container.decode(.url, String.self, "")
         enabled = container.decode(.enabled, Bool.self, false)
         latency = container.decode(.latency, Int32.self, 2000)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
         transport = container.decode(.transport, SettingsRtspTransport.self, .rtpRtspTcp)
     }
 
@@ -415,6 +475,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
     @Published var name: String = baseName
     @Published var streamKey: String = ""
     @Published var latency: Int32 = 100
+    @Published var intrinsicDelay: Int32 = 0
     @Published var syncTimestamps: Bool = true
 
     enum CodingKeys: CodingKey {
@@ -422,6 +483,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         case name
         case streamKey
         case latency
+        case intrinsicDelay
         case syncTimestamps
     }
 
@@ -431,6 +493,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.name, name)
         try container.encode(.streamKey, streamKey)
         try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
         try container.encode(.syncTimestamps, syncTimestamps)
     }
 
@@ -442,6 +505,7 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         name = container.decode(.name, String.self, Self.baseName)
         streamKey = container.decode(.streamKey, String.self, "")
         latency = container.decode(.latency, Int32.self, 100)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
         syncTimestamps = container.decode(.syncTimestamps, Bool.self, true)
     }
 
@@ -453,12 +517,17 @@ class SettingsWhipServerStream: Codable, Identifiable, ObservableObject, Named {
         Double(latency) / 1000
     }
 
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
+    }
+
     func clone() -> SettingsWhipServerStream {
         let new = SettingsWhipServerStream()
         new.id = id
         new.name = name
         new.streamKey = streamKey
         new.latency = latency
+        new.intrinsicDelay = intrinsicDelay
         new.syncTimestamps = syncTimestamps
         return new
     }
@@ -509,6 +578,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
     @Published var url: String = ""
     @Published var enabled: Bool = false
     @Published var latency: Int32 = 100
+    @Published var intrinsicDelay: Int32 = 0
     @Published var syncTimestamps: Bool = true
 
     enum CodingKeys: CodingKey {
@@ -517,11 +587,16 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         case url
         case enabled
         case latency
+        case intrinsicDelay
         case syncTimestamps
     }
 
     func latencySeconds() -> Double {
         Double(latency) / 1000
+    }
+
+    func intrinsicDelaySeconds() -> Double {
+        Double(intrinsicDelay) / 1000
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -531,6 +606,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.url, url)
         try container.encode(.enabled, enabled)
         try container.encode(.latency, latency)
+        try container.encode(.intrinsicDelay, intrinsicDelay)
         try container.encode(.syncTimestamps, syncTimestamps)
     }
 
@@ -543,6 +619,7 @@ class SettingsWhepClientStream: Codable, Identifiable, ObservableObject, Named {
         url = container.decode(.url, String.self, "")
         enabled = container.decode(.enabled, Bool.self, false)
         latency = container.decode(.latency, Int32.self, 100)
+        intrinsicDelay = container.decode(.intrinsicDelay, Int32.self, 0)
         syncTimestamps = container.decode(.syncTimestamps, Bool.self, true)
     }
 

--- a/Moblin/Various/Settings/SettingsScene.swift
+++ b/Moblin/Various/Settings/SettingsScene.swift
@@ -3889,6 +3889,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject, Named {
     @Published var videoStabilizationMode: SettingsVideoStabilizationMode = .off
     @Published var overrideVideoStabilizationMode: Bool = false
     @Published var fillFrame: Bool = false
+    @Published var networkSourceSynchronizationEnabled: Bool = false
     @Published var overrideMic: Bool = false
     @Published var micId: String = ""
     @Published var quickSwitchGroup: Int?
@@ -3925,6 +3926,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject, Named {
         case videoStabilizationMode
         case overrideVideoStabilizationMode
         case fillFrame
+        case networkSourceSynchronizationEnabled
         case overrideMic
         case micId
         case quickSwitchGroup
@@ -3954,6 +3956,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject, Named {
         try container.encode(.videoStabilizationMode, videoStabilizationMode)
         try container.encode(.overrideVideoStabilizationMode, overrideVideoStabilizationMode)
         try container.encode(.fillFrame, fillFrame)
+        try container.encode(.networkSourceSynchronizationEnabled, networkSourceSynchronizationEnabled)
         try container.encode(.overrideMic, overrideMic)
         try container.encode(.micId, micId)
         try container.encode(.quickSwitchGroup, quickSwitchGroup)
@@ -3991,6 +3994,11 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject, Named {
         )
         overrideVideoStabilizationMode = container.decode(.overrideVideoStabilizationMode, Bool.self, false)
         fillFrame = container.decode(.fillFrame, Bool.self, false)
+        networkSourceSynchronizationEnabled = container.decode(
+            .networkSourceSynchronizationEnabled,
+            Bool.self,
+            false
+        )
         overrideMic = container.decode(.overrideMic, Bool.self, false)
         micId = container.decode(.micId, String.self, "")
         quickSwitchGroup = container.decode(.quickSwitchGroup, Int?.self, nil)
@@ -4008,6 +4016,7 @@ class SettingsScene: Codable, Identifiable, Equatable, ObservableObject, Named {
         new.videoStabilizationMode = videoStabilizationMode
         new.overrideVideoStabilizationMode = overrideVideoStabilizationMode
         new.fillFrame = fillFrame
+        new.networkSourceSynchronizationEnabled = networkSourceSynchronizationEnabled
         new.overrideMic = overrideMic
         new.micId = micId
         new.quickSwitchGroup = quickSwitchGroup

--- a/Moblin/View/Settings/Debug/DebugSettingsView.swift
+++ b/Moblin/View/Settings/Debug/DebugSettingsView.swift
@@ -100,18 +100,6 @@ struct DebugSettingsView: View {
                 }
                 Toggle("Relaxed bitrate decrement after scene switch", isOn: $debug.relaxedBitrate)
                 Toggle("Twitch rewards", isOn: $debug.twitchRewards)
-                VStack(alignment: .leading) {
-                    Text("Builtin audio and video delay")
-                    HStack {
-                        Slider(
-                            value: $debug.builtinAudioAndVideoDelay,
-                            in: 0.0 ... 4.0,
-                            step: 0.01
-                        )
-                        Text(formatTwoDecimals(debug.builtinAudioAndVideoDelay))
-                            .frame(width: 40)
-                    }
-                }
                 Toggle(String("Enhanced Moblin SRT"), isOn: $debug.enhancedMoblinSrt)
                 Toggle("Web browser bonding", isOn: $debug.httpProxy)
                     .onChange(of: debug.httpProxy) { _ in

--- a/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RistServer/RistServerStreamSettingsView.swift
@@ -58,6 +58,12 @@ struct RistServerStreamSettingsView: View {
                     Text("The higher, the lower risk of stuttering.")
                 }
                 Section {
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                    }
+                    .disabled(ristServer.enabled)
+                }
+                Section {
                     UrlsView(
                         status: status,
                         showIPv6: false,

--- a/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RtmpServer/RtmpServerStreamSettingsView.swift
@@ -77,6 +77,12 @@ struct RtmpServerStreamSettingsView: View {
                     Text("The higher, the lower risk of stuttering.")
                 }
                 Section {
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                    }
+                    .disabled(model.rtmpServerEnabled())
+                }
+                Section {
                     Toggle("Drift tracking", isOn: $stream.trackDrift)
                         .disabled(model.rtmpServerEnabled())
                 } footer: {

--- a/Moblin/View/Settings/Ingests/RtspClient/RtspClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/RtspClient/RtspClientStreamSettingsView.swift
@@ -139,6 +139,12 @@ struct RtspClientStreamSettingsView: View {
                 } footer: {
                     Text("The higher, the lower risk of stuttering.")
                 }
+                Section {
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                        model.reloadRtspClient()
+                    }
+                }
             }
             .navigationTitle("Stream")
         } label: {

--- a/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtClient/SrtClientStreamSettingsView.swift
@@ -31,6 +31,25 @@ struct SrtClientStreamSettingsView: View {
                         TextItemLocalizedView(name: "URL", value: stream.url, sensitive: true)
                     }
                 }
+                Section {
+                    TextEditNavigationView(
+                        title: String(localized: "Latency"),
+                        value: String(stream.latency),
+                        onChange: isValidIngestLatency,
+                        onSubmit: { value in
+                            guard let latency = Int32(value) else { return }
+                            stream.latency = latency
+                            model.reloadSrtClient()
+                        },
+                        footers: [String(localized: "5 or more milliseconds. 500 ms by default.")],
+                        keyboardType: .numbersAndPunctuation,
+                        valueFormat: { "\($0) ms" }
+                    )
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                        model.reloadSrtClient()
+                    }
+                }
             }
             .navigationTitle("Stream")
         } label: {

--- a/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/SrtlaServer/SrtlaServerStreamSettingsView.swift
@@ -55,6 +55,25 @@ struct SrtlaServerStreamSettingsView: View {
                     Text("The stream name is shown in the list of cameras in scene settings.")
                 }
                 Section {
+                    TextEditNavigationView(
+                        title: String(localized: "Latency"),
+                        value: String(stream.latency),
+                        onChange: isValidIngestLatency,
+                        onSubmit: { value in
+                            guard let latency = Int32(value) else { return }
+                            stream.latency = latency
+                        },
+                        footers: [String(localized: "5 or more milliseconds. 500 ms by default.")],
+                        keyboardType: .numbersAndPunctuation,
+                        valueFormat: { "\($0) ms" }
+                    )
+                    .disabled(srtlaServer.enabled)
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                    }
+                    .disabled(srtlaServer.enabled)
+                }
+                Section {
                     UrlsView(
                         status: status,
                         title: String(localized: "SRT URLs"),

--- a/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhepClient/WhepClientStreamSettingsView.swift
@@ -46,6 +46,13 @@ struct WhepClientStreamSettingsView: View {
                     Text("The higher, the lower risk of stuttering.")
                 }
                 Section {
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                        model.reloadWhepClient()
+                    }
+                    .disabled(stream.enabled)
+                }
+                Section {
                     Toggle("Sync timestamps", isOn: $stream.syncTimestamps)
                         .onChange(of: stream.syncTimestamps) { _ in
                             model.reloadWhepClient()

--- a/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
+++ b/Moblin/View/Settings/Ingests/WhipServer/WhipServerStreamSettingsView.swift
@@ -60,6 +60,12 @@ struct WhipServerStreamSettingsView: View {
                     Text("The higher, the lower risk of stuttering.")
                 }
                 Section {
+                    CameraProcessingDelayEditView(value: stream.intrinsicDelay) {
+                        stream.intrinsicDelay = $0
+                    }
+                    .disabled(whipServer.enabled)
+                }
+                Section {
                     Toggle("Sync timestamps", isOn: $stream.syncTimestamps)
                         .disabled(whipServer.enabled)
                 }

--- a/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Scene/SceneSettingsView.swift
@@ -340,6 +340,29 @@ struct SceneShortcutView: View {
     }
 }
 
+private struct NetworkSourceSynchronizationView: View {
+    @EnvironmentObject var model: Model
+    @ObservedObject var scene: SettingsScene
+
+    var body: some View {
+        Section {
+            Toggle("Synchronize network sources", isOn: $scene.networkSourceSynchronizationEnabled)
+                .onChange(of: scene.networkSourceSynchronizationEnabled) { _ in
+                    if model.getSelectedScene() === scene {
+                        model.sceneUpdated(updateRemoteScene: false)
+                    }
+                }
+        } footer: {
+            Text(
+                """
+                Align visible network sources with built-in cameras and microphones using \
+                            each source's latency and camera processing delay.
+                """
+            )
+        }
+    }
+}
+
 struct SceneSettingsView: View {
     let database: Database
     @ObservedObject var scene: SettingsScene
@@ -348,6 +371,7 @@ struct SceneSettingsView: View {
         Form {
             NameEditView(name: $scene.name, existingNames: database.scenes)
             VideoSourceView(database: database, scene: scene)
+            NetworkSourceSynchronizationView(scene: scene)
             QuickSwitchGroupView(database: database, scene: scene)
             SceneMicView(database: database, scene: scene)
             WidgetsView(database: database, scene: scene)

--- a/Moblin/View/Utils/CameraProcessingDelayEditView.swift
+++ b/Moblin/View/Utils/CameraProcessingDelayEditView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct CameraProcessingDelayEditView: View {
+    let value: Int32
+    let onSubmit: (Int32) -> Void
+
+    var body: some View {
+        TextEditNavigationView(
+            title: String(localized: "Camera processing delay"),
+            value: String(value),
+            onChange: { value in
+                guard let delay = Int32(value), delay >= 0 else {
+                    return String(localized: "Must be zero or more milliseconds")
+                }
+                return nil
+            },
+            onSubmit: { value in
+                guard let delay = Int32(value), delay >= 0 else {
+                    return
+                }
+                onSubmit(delay)
+            },
+            footers: [
+                String(localized: "0 ms by default."),
+                String(
+                    localized: "Additional delay introduced by this camera before its stream reaches Moblin."
+                ),
+            ],
+            keyboardType: .numbersAndPunctuation,
+            valueFormat: { "\($0) ms" }
+        )
+    }
+}

--- a/MoblinTests/SceneSynchronizationPlanSuite.swift
+++ b/MoblinTests/SceneSynchronizationPlanSuite.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import Moblin
+import Testing
+
+struct SceneSynchronizationPlanSuite {
+    private let accuracy = 0.000_001
+
+    @Test
+    func sceneSynchronizationIsDisabledByDefaultAndPersists() throws {
+        let scene = SettingsScene(name: "Test")
+        #expect(!scene.networkSourceSynchronizationEnabled)
+
+        scene.networkSourceSynchronizationEnabled = true
+        let decoded = try JSONDecoder().decode(SettingsScene.self, from: JSONEncoder().encode(scene))
+
+        #expect(decoded.networkSourceSynchronizationEnabled)
+    }
+
+    @Test
+    func noSourcesNeedsNoBuiltinDelay() {
+        let plan = SceneSynchronizationPlan.make(sources: [])
+
+        #expect(plan.builtinDelay == 0)
+        #expect(plan.additionalDelays.isEmpty)
+    }
+
+    @Test
+    func oneSourceKeepsItsConfiguredLatencyTarget() {
+        let id = UUID()
+        let plan = SceneSynchronizationPlan.make(sources: [
+            .init(id: id, latency: 2.0, intrinsicDelay: 0.4),
+        ])
+
+        #expect(abs(plan.builtinDelay - 2.4) < accuracy)
+        #expect(plan.additionalDelays[id] == 0)
+    }
+
+    @Test
+    func sourcesAlignAtLargestEffectiveDelay() throws {
+        let rtmp = UUID()
+        let srt = UUID()
+        let rist = UUID()
+        let sources = [
+            NetworkSourceDelay(id: rtmp, latency: 2.0, intrinsicDelay: 0.4),
+            NetworkSourceDelay(id: srt, latency: 0.8, intrinsicDelay: 0.3),
+            NetworkSourceDelay(id: rist, latency: 1.5, intrinsicDelay: 0.6),
+        ]
+        let plan = SceneSynchronizationPlan.make(sources: sources)
+
+        #expect(abs(plan.builtinDelay - 2.4) < accuracy)
+        #expect(plan.additionalDelays[rtmp] == 0)
+        #expect(try abs(#require(plan.additionalDelays[srt]) - 1.3) < accuracy)
+        #expect(try abs(#require(plan.additionalDelays[rist]) - 0.3) < accuracy)
+        for source in sources {
+            #expect(abs(source.effectiveDelay + plan.additionalDelays[source.id]! - plan.builtinDelay) <
+                accuracy)
+        }
+    }
+
+    @Test
+    func equalEffectiveDelaysNeedNoAdditionalDelay() {
+        let first = UUID()
+        let second = UUID()
+        let plan = SceneSynchronizationPlan.make(sources: [
+            .init(id: first, latency: 1.0, intrinsicDelay: 0.5),
+            .init(id: second, latency: 0.5, intrinsicDelay: 1.0),
+        ])
+
+        #expect(abs(plan.builtinDelay - 1.5) < accuracy)
+        #expect(plan.additionalDelays[first] == 0)
+        #expect(plan.additionalDelays[second] == 0)
+    }
+}

--- a/MoblinTests/SceneSynchronizationPlanSuite.swift
+++ b/MoblinTests/SceneSynchronizationPlanSuite.swift
@@ -25,14 +25,14 @@ struct SceneSynchronizationPlanSuite {
     }
 
     @Test
-    func oneSourceKeepsItsConfiguredLatencyTarget() {
+    func oneSourceKeepsItsConfiguredLatencyTarget() throws {
         let id = UUID()
         let plan = SceneSynchronizationPlan.make(sources: [
             .init(id: id, latency: 2.0, intrinsicDelay: 0.4),
         ])
 
         #expect(abs(plan.builtinDelay - 2.4) < accuracy)
-        #expect(plan.additionalDelays[id] == 0)
+        #expect(try abs(#require(plan.additionalDelays[id])) < accuracy)
     }
 
     @Test
@@ -48,7 +48,7 @@ struct SceneSynchronizationPlanSuite {
         let plan = SceneSynchronizationPlan.make(sources: sources)
 
         #expect(abs(plan.builtinDelay - 2.4) < accuracy)
-        #expect(plan.additionalDelays[rtmp] == 0)
+        #expect(try abs(#require(plan.additionalDelays[rtmp])) < accuracy)
         #expect(try abs(#require(plan.additionalDelays[srt]) - 1.3) < accuracy)
         #expect(try abs(#require(plan.additionalDelays[rist]) - 0.3) < accuracy)
         for source in sources {
@@ -58,7 +58,7 @@ struct SceneSynchronizationPlanSuite {
     }
 
     @Test
-    func equalEffectiveDelaysNeedNoAdditionalDelay() {
+    func equalEffectiveDelaysNeedNoAdditionalDelay() throws {
         let first = UUID()
         let second = UUID()
         let plan = SceneSynchronizationPlan.make(sources: [
@@ -67,7 +67,20 @@ struct SceneSynchronizationPlanSuite {
         ])
 
         #expect(abs(plan.builtinDelay - 1.5) < accuracy)
-        #expect(plan.additionalDelays[first] == 0)
-        #expect(plan.additionalDelays[second] == 0)
+        #expect(try abs(#require(plan.additionalDelays[first])) < accuracy)
+        #expect(try abs(#require(plan.additionalDelays[second])) < accuracy)
+    }
+
+    @Test
+    func duplicateSourceIdsUseTheLatestDescriptorOnce() throws {
+        let id = UUID()
+        let plan = SceneSynchronizationPlan.make(sources: [
+            .init(id: id, latency: 1.0, intrinsicDelay: 0.0),
+            .init(id: id, latency: 2.0, intrinsicDelay: 0.5),
+        ])
+
+        #expect(abs(plan.builtinDelay - 2.5) < accuracy)
+        #expect(plan.additionalDelays.count == 1)
+        #expect(try abs(#require(plan.additionalDelays[id])) < accuracy)
     }
 }


### PR DESCRIPTION
# Network source delay alignment

## Summary

Adds optional per-scene synchronization for built-in and network sources.

## Changes

- Adds persisted per-stream `intrinsicDelay` settings for network sources.
- Aligns visible network sources using:

  ```text
  effectiveDelay_i = L_i + C_i
  sceneDelay = max(effectiveDelay_i)
  ```

- Delays built-in cameras and microphones by `sceneDelay`.
- Delays network sources by the remaining amount:

  ```text
  additionalDelay_i = sceneDelay - (L_i + C_i)
  ```

- Adds a per-scene **Synchronize network sources** toggle.
  - Disabled by default.
  - Existing and new scenes remain unsynchronized unless explicitly enabled.
- Adds shared camera-processing-delay editing UI.
- Uses negotiated `SRTO_RCVLATENCY` for SRT and SRTLA sources rather than assuming the persisted value is the negotiated transport latency.
- Replans SRT/SRTLA sources after reconnect only when the negotiated latency or active scene plan changes.
- Preserves protocol-specific audio/video target corrections from `TargetLatenciesSynchronizer`.
- Adds unit tests for the synchronization plan, persistence default, alignment math, equal delays, and duplicate source IDs.