### PR TITLE
Connection status sound

### DIFF
--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -65033,6 +65033,9 @@
         }
       }
     },
+    "Connection status sound" : {
+
+    },
     "Contains" : {
 
     },

--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -235703,6 +235703,12 @@
         }
       }
     },
+    "Tap to disable the beep sound" : {
+
+    },
+    "Tap to enable the beep sound" : {
+
+    },
     "Tap to focus not supported for this camera" : {
       "localizations" : {
         "de" : {

--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -235706,12 +235706,6 @@
         }
       }
     },
-    "Tap to disable the beep sound" : {
-
-    },
-    "Tap to enable the beep sound" : {
-
-    },
     "Tap to focus not supported for this camera" : {
       "localizations" : {
         "de" : {

--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -85173,6 +85173,9 @@
         }
       }
     },
+    "Enable to play a short sound when the stream fails to connect." : {
+
+    },
     "Enable to vibrate the device when the following toasts appear:" : {
       "localizations" : {
         "de" : {

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -460,6 +460,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     let moblink = Moblink()
     let ingests = Ingests()
     let bitrate = Bitrate()
+    var connectionStatusSoundPlayer: AudioPlayer?
     let bonding = Bonding()
     var currentFps: Int?
     var currentResolution: String?

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -461,6 +461,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     let ingests = Ingests()
     let bitrate = Bitrate()
     var connectionStatusSoundPlayer: AudioPlayer?
+    var connectionStatusSoundEnabled = true
     let bonding = Bonding()
     var currentFps: Int?
     var currentResolution: String?
@@ -886,13 +887,19 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         }
     }
 
-    func makeErrorToast(title: String, font: Font? = nil, subTitle: String? = nil, vibrate: Bool = false) {
+    func makeErrorToast(title: String,
+                        font: Font? = nil,
+                        subTitle: String? = nil,
+                        vibrate: Bool = false,
+                        onTapped: (() -> Void)? = nil)
+    {
         toast.toast = AlertToast(
             type: .regular,
             title: title,
             subTitle: subTitle,
             style: .style(titleColor: .red, titleFont: font, subTitleFont: .body)
         )
+        toast.onTapped = onTapped
         showToast()
         logger.debug("toast: Error: \(title): \(subTitle ?? "-")")
         if vibrate {

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -461,7 +461,6 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     let ingests = Ingests()
     let bitrate = Bitrate()
     var connectionStatusSoundPlayer: AudioPlayer?
-    var connectionStatusSoundEnabled = true
     let bonding = Bonding()
     var currentFps: Int?
     var currentResolution: String?
@@ -887,19 +886,13 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
         }
     }
 
-    func makeErrorToast(title: String,
-                        font: Font? = nil,
-                        subTitle: String? = nil,
-                        vibrate: Bool = false,
-                        onTapped: (() -> Void)? = nil)
-    {
+    func makeErrorToast(title: String, font: Font? = nil, subTitle: String? = nil, vibrate: Bool = false) {
         toast.toast = AlertToast(
             type: .regular,
             title: title,
             subTitle: subTitle,
             style: .style(titleColor: .red, titleFont: font, subTitleFont: .body)
         )
-        toast.onTapped = onTapped
         showToast()
         logger.debug("toast: Error: \(title): \(subTitle ?? "-")")
         if vibrate {

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -542,6 +542,18 @@ extension Model {
         updateStreamUptime(now: .now)
     }
 
+    private func playConnectionStatusSound() {
+        if connectionStatusSoundPlayer == nil,
+           let soundUrl = Bundle.main.url(
+               forResource: "Alerts.bundle/Notification",
+               withExtension: "mp3"
+           )
+        {
+            connectionStatusSoundPlayer = try? AudioPlayer(contentsOf: soundUrl)
+        }
+        connectionStatusSoundPlayer?.play()
+    }
+
     private func onDisconnected(reason: String) {
         guard streaming else {
             return
@@ -553,6 +565,9 @@ extension Model {
             makeFffffToast(subTitle: subTitle)
         } else if streamState == .connecting {
             makeConnectFailureToast(subTitle: subTitle)
+            if database.show.connectionStatusSound {
+                playConnectionStatusSound()
+            }
         }
         streamState = .disconnected
         stopNetStream()

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -579,6 +579,9 @@ extension Model {
         if streamState == .connected {
             streamTotalBytes += UInt64(media.streamTotal())
             makeFffffToast(subTitle: subTitle)
+            if database.show.connectionStatusSound, connectionStatusSoundEnabled {
+                playConnectionStatusSound()
+            }
         } else if streamState == .connecting {
             makeConnectFailureToast(subTitle: subTitle)
             if database.show.connectionStatusSound, connectionStatusSoundEnabled {

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -521,25 +521,9 @@ extension Model {
     }
 
     private func makeConnectFailureToast(subTitle: String) {
-        guard database.show.connectionStatusSound else {
-            makeErrorToast(
-                title: failedToConnectMessage(stream.name),
-                subTitle: subTitle,
-                vibrate: true
-            )
-            return
-        }
-        let soundAction = connectionStatusSoundEnabled
-            ? String(localized: "Tap to disable the beep sound")
-            : String(localized: "Tap to enable the beep sound")
-        makeErrorToast(
-            title: failedToConnectMessage(stream.name),
-            subTitle: "\(subTitle)\n\(soundAction)",
-            vibrate: true,
-            onTapped: { [weak self] in
-                self?.connectionStatusSoundEnabled.toggle()
-            }
-        )
+        makeErrorToast(title: failedToConnectMessage(stream.name),
+                       subTitle: subTitle,
+                       vibrate: true)
     }
 
     private func makeFffffToast(subTitle: String) {
@@ -579,12 +563,12 @@ extension Model {
         if streamState == .connected {
             streamTotalBytes += UInt64(media.streamTotal())
             makeFffffToast(subTitle: subTitle)
-            if database.show.connectionStatusSound, connectionStatusSoundEnabled {
+            if database.show.connectionStatusSound {
                 playConnectionStatusSound()
             }
         } else if streamState == .connecting {
             makeConnectFailureToast(subTitle: subTitle)
-            if database.show.connectionStatusSound, connectionStatusSoundEnabled {
+            if database.show.connectionStatusSound {
                 playConnectionStatusSound()
             }
         }

--- a/Moblin/Various/Model/ModelStream.swift
+++ b/Moblin/Various/Model/ModelStream.swift
@@ -521,9 +521,25 @@ extension Model {
     }
 
     private func makeConnectFailureToast(subTitle: String) {
-        makeErrorToast(title: failedToConnectMessage(stream.name),
-                       subTitle: subTitle,
-                       vibrate: true)
+        guard database.show.connectionStatusSound else {
+            makeErrorToast(
+                title: failedToConnectMessage(stream.name),
+                subTitle: subTitle,
+                vibrate: true
+            )
+            return
+        }
+        let soundAction = connectionStatusSoundEnabled
+            ? String(localized: "Tap to disable the beep sound")
+            : String(localized: "Tap to enable the beep sound")
+        makeErrorToast(
+            title: failedToConnectMessage(stream.name),
+            subTitle: "\(subTitle)\n\(soundAction)",
+            vibrate: true,
+            onTapped: { [weak self] in
+                self?.connectionStatusSoundEnabled.toggle()
+            }
+        )
     }
 
     private func makeFffffToast(subTitle: String) {
@@ -565,7 +581,7 @@ extension Model {
             makeFffffToast(subTitle: subTitle)
         } else if streamState == .connecting {
             makeConnectFailureToast(subTitle: subTitle)
-            if database.show.connectionStatusSound {
+            if database.show.connectionStatusSound, connectionStatusSoundEnabled {
                 playConnectionStatusSound()
             }
         }

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -142,6 +142,7 @@ class SettingsShow: Codable, ObservableObject {
     @Published var uptime: Bool = true
     @Published var stream: Bool = false
     @Published var speed: Bool = true
+    @Published var connectionStatusSound: Bool = false
     @Published var audioLevel: Bool = true
     @Published var zoom: Bool = false
     @Published var zoomPresets: Bool = true
@@ -171,6 +172,7 @@ class SettingsShow: Codable, ObservableObject {
         case uptime
         case stream
         case speed
+        case connectionStatusSound
         case audioLevel
         case zoom
         case zoomPresets
@@ -200,6 +202,7 @@ class SettingsShow: Codable, ObservableObject {
         try container.encode(.uptime, uptime)
         try container.encode(.stream, stream)
         try container.encode(.speed, speed)
+        try container.encode(.connectionStatusSound, connectionStatusSound)
         try container.encode(.audioLevel, audioLevel)
         try container.encode(.zoom, zoom)
         try container.encode(.zoomPresets, zoomPresets)
@@ -229,6 +232,7 @@ class SettingsShow: Codable, ObservableObject {
         uptime = container.decode(.uptime, Bool.self, true)
         stream = container.decode(.stream, Bool.self, false)
         speed = container.decode(.speed, Bool.self, true)
+        connectionStatusSound = container.decode(.connectionStatusSound, Bool.self, false)
         audioLevel = container.decode(.audioLevel, Bool.self, true)
         zoom = container.decode(.zoom, Bool.self, false)
         zoomPresets = container.decode(.zoomPresets, Bool.self, true)

--- a/Moblin/View/Settings/Display/DisplaySettingsView.swift
+++ b/Moblin/View/Settings/Display/DisplaySettingsView.swift
@@ -57,6 +57,7 @@ struct DisplaySettingsView: View {
                     .onChange(of: database.vibrate) { _ in
                         model.setAllowHapticsAndSystemSoundsDuringRecording()
                     }
+                Toggle("Connection status sound", isOn: $database.show.connectionStatusSound)
             } footer: {
                 VStack(alignment: .leading) {
                     Text("Enable to vibrate the device when the following toasts appear:")

--- a/Moblin/View/Settings/Display/DisplaySettingsView.swift
+++ b/Moblin/View/Settings/Display/DisplaySettingsView.swift
@@ -57,7 +57,6 @@ struct DisplaySettingsView: View {
                     .onChange(of: database.vibrate) { _ in
                         model.setAllowHapticsAndSystemSoundsDuringRecording()
                     }
-                Toggle("Connection status sound", isOn: $database.show.connectionStatusSound)
             } footer: {
                 VStack(alignment: .leading) {
                     Text("Enable to vibrate the device when the following toasts appear:")
@@ -71,6 +70,14 @@ struct DisplaySettingsView: View {
                     Text("Make sure silent mode is off for vibrations to work.")
                 }
             }
+            Section {
+                Toggle("Connection status sound", isOn: $database.show.connectionStatusSound)
+            } footer: {
+                VStack(alignment: .leading) {
+                    Text("Enable to play a short sound when the stream fails to connect.")
+                }
+            }
+
             if database.showAllSettings {
                 if !isMac() {
                     Section {

--- a/Moblin/View/Settings/Display/LocalOverlays/LocalOverlaysSettingsView.swift
+++ b/Moblin/View/Settings/Display/LocalOverlays/LocalOverlaysSettingsView.swift
@@ -94,6 +94,11 @@ struct LocalOverlaysSettingsView: View {
                     Image(systemName: "speedometer")
                 }
                 Label {
+                    Toggle("Connection status sound", isOn: $show.connectionStatusSound)
+                } icon: {
+                    Image(systemName: "speaker.wave.2")
+                }
+                Label {
                     Toggle("Uptime", isOn: $show.uptime)
                 } icon: {
                     Image(systemName: "deskclock")

--- a/Moblin/View/Settings/Display/LocalOverlays/LocalOverlaysSettingsView.swift
+++ b/Moblin/View/Settings/Display/LocalOverlays/LocalOverlaysSettingsView.swift
@@ -94,11 +94,6 @@ struct LocalOverlaysSettingsView: View {
                     Image(systemName: "speedometer")
                 }
                 Label {
-                    Toggle("Connection status sound", isOn: $show.connectionStatusSound)
-                } icon: {
-                    Image(systemName: "speaker.wave.2")
-                }
-                Label {
                     Toggle("Uptime", isOn: $show.uptime)
                 } icon: {
                     Image(systemName: "deskclock")


### PR DESCRIPTION
beep on connection failure, when the alert toast is displayed. The corresponding toggle is in Display, Local overlays, where connection timeline was, maybe not the best place. Tap on the alert toast disables or re-enables the beep temporarily. Using Notification.mp3 for now. A clearer beep is needed