### PR TITLE
End workouts the way Apple documents

### DIFF
--- a/Moblin Watch/Various/WatchModel.swift
+++ b/Moblin Watch/Various/WatchModel.swift
@@ -365,9 +365,8 @@ class WatchModel: NSObject, ObservableObject, @unchecked Sendable {
     }
 
     func stopWorkout() {
-        workoutBuilder?.finishWorkout { _, _ in }
-        workoutSession?.end()
         control.workoutActive = false
+        workoutSession?.stopActivity(with: .now)
     }
 
     private func startWorkoutAuthorized(type: WatchProtocolWorkoutType) {
@@ -595,11 +594,22 @@ extension WatchModel: WCSessionDelegate {
 
 extension WatchModel: HKWorkoutSessionDelegate {
     func workoutSession(
-        _: HKWorkoutSession,
-        didChangeTo _: HKWorkoutSessionState,
+        _ session: HKWorkoutSession,
+        didChangeTo toState: HKWorkoutSessionState,
         from _: HKWorkoutSessionState,
-        date _: Date
-    ) {}
+        date: Date
+    ) {
+        guard toState == .stopped, session === workoutSession, let builder = workoutBuilder else {
+            return
+        }
+        workoutSession = nil
+        workoutBuilder = nil
+        builder.endCollection(withEnd: date) { _, _ in
+            builder.finishWorkout { _, _ in
+                session.end()
+            }
+        }
+    }
 
     func workoutSession(_: HKWorkoutSession, didFailWithError _: any Error) {}
 }

--- a/Moblin/Various/Model/ModelWorkout.swift
+++ b/Moblin/Various/Model/ModelWorkout.swift
@@ -71,17 +71,28 @@ class Workout: NSObject, @unchecked Sendable {
     }
 
     func stop() {
-        workoutBuilder?.finishWorkout { _, _ in }
-        workoutSession?.end()
+        workoutSession?.stopActivity(with: .now)
     }
 }
 
 @available(iOS 26.0, *)
 extension Workout: HKWorkoutSessionDelegate {
-    func workoutSession(_: HKWorkoutSession,
-                        didChangeTo _: HKWorkoutSessionState,
+    func workoutSession(_ session: HKWorkoutSession,
+                        didChangeTo toState: HKWorkoutSessionState,
                         from _: HKWorkoutSessionState,
-                        date _: Date) {}
+                        date: Date)
+    {
+        guard toState == .stopped, session === workoutSession, let builder = workoutBuilder else {
+            return
+        }
+        workoutSession = nil
+        workoutBuilder = nil
+        builder.endCollection(withEnd: date) { _, _ in
+            builder.finishWorkout { _, _ in
+                session.end()
+            }
+        }
+    }
 
     func workoutSession(_: HKWorkoutSession, didFailWithError _: any Error) {}
 }


### PR DESCRIPTION
## Why

Makes workouts save reliably, with the data collected during them, on both the phone and the watch.
I was not getting workouts into the Health app after short rides, and the ending sequence looks like
the reason.

## Summary

`stop()` calls `finishWorkout()` first, while the session is still running and collection is still
open:

```swift
workoutBuilder?.finishWorkout { _, _ in }
workoutSession?.end()
```

Apple documents the opposite order, in
[Running workout sessions](https://developer.apple.com/documentation/healthkit/running-workout-sessions):

> After the user finishes the workout, stop the session by calling `stopActivity(with:)`.
>
> After the session has transitioned to the `.stopped` state, call the builder's
> `endCollection(withEnd:completion:)` and `finishWorkout(completion:)` methods. Finally, call
> `end()` to end the session.

`endCollection(withEnd:)` is what sets the workout's end date and deactivates the builder, and it is
not called anywhere in the app. Both completion handlers discard their errors, so if `finishWorkout`
does fail there is nothing to see.

## The fix

Follow the documented order. `stop()` now only stops the activity:

```swift
func stop() {
    workoutSession?.stopActivity(with: .now)
}
```

and the rest happens on the `.stopped` transition in the session delegate, which was an empty stub
on both platforms:

```swift
guard toState == .stopped, session === workoutSession, let builder = workoutBuilder else {
    return
}
workoutSession = nil
workoutBuilder = nil
builder.endCollection(withEnd: date) { _, _ in
    builder.finishWorkout { _, _ in
        session.end()
    }
}
```

The identity check and clearing both references up front mean a workout that is still finishing
cannot be confused with a new one started straight after it.

Same change on the phone and on the watch.

## Test plan

- [x] Start a workout from the Apple Watch, ride for a minute, stop it
- [x] The saved workout shows up afterwards
- [x] Same from the iPhone on iOS 26

Checked two ways. On real hardware, two workouts on an indoor trainer — one started from the iPhone,
one from the Apple Watch — both present afterwards. Then again on the iOS 27 and watchOS 27
simulators once the sequence was rewritten to match the documentation, on both platforms.
## Note

No version-history entry — the changelog reads as feature-oriented. Happy to add one if you would
prefer it there.

## Screenshots

**Started on the iPhone, saved afterwards**

<img width="645" height="1398" alt="iOS WRK" src="https://github.com/user-attachments/assets/da43d46b-abdb-46c4-8748-9f3435217974" />

**Started on the Apple Watch, saved afterwards**

<img width="645" height="1398" alt="watchOS WRK" src="https://github.com/user-attachments/assets/336e445f-3106-4f8d-a200-ab6a3861ca72" />

## Attribution

Written by Claude under my direction. Tested by me on real hardware — an indoor trainer setup, not
an outdoor bike.
