### PR TITLE
Add BLE cycling speed and cadence (CSC) workout device support

### DIFF
--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -275438,7 +275438,7 @@
         }
       }
     },
-    "Used to calculate speed from cycling speed and cadence (CSC) sensors." : {
+    "Used to calculate speed from wheel revolutions." : {
 
     },
     "Useful when using an external camera and a portrait phone holder." : {

--- a/Common/Localizable.xcstrings
+++ b/Common/Localizable.xcstrings
@@ -218475,6 +218475,9 @@
         }
       }
     },
+    "Show cycling speed" : {
+
+    },
     "Show date as %@" : {
       "localizations" : {
         "de" : {
@@ -275435,6 +275438,9 @@
         }
       }
     },
+    "Used to calculate speed from cycling speed and cadence (CSC) sensors." : {
+
+    },
     "Useful when using an external camera and a portrait phone holder." : {
       "localizations" : {
         "de" : {
@@ -283700,6 +283706,9 @@
           }
         }
       }
+    },
+    "Wheel circumference" : {
+
     },
     "Wheel of luck" : {
       "localizations" : {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -14,8 +14,7 @@ protocol WorkoutDeviceDelegate: AnyObject {
     func workoutDeviceState(_ device: WorkoutDevice, state: WorkoutDeviceState)
     func workoutDeviceHeartRate(_ device: WorkoutDevice, heartRate: Int)
     func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int?)
-    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice,
-                                          metrics: WorkoutDeviceCyclingSpeedCadenceMetrics)
+    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice, speed: Double?, cadence: Int?)
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics)
 }
 
@@ -32,14 +31,18 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
     private var peripheral: CBPeripheral?
     private let heartRate = WorkoutDeviceHeartRate()
     private let cyclingPower = WorkoutDeviceCyclingPower()
-    private let cyclingSpeedCadence = WorkoutDeviceCyclingSpeedCadence()
+    private let cyclingSpeedCadence: WorkoutDeviceCyclingSpeedCadence
     private let running = WorkoutDeviceRunning()
     private var deviceId: UUID?
     weak var delegate: (any WorkoutDeviceDelegate)?
 
-    func start(deviceId: UUID?, wheelCircumference: Int) {
+    init(wheelCircumference: Int) {
+        cyclingSpeedCadence = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: wheelCircumference)
+        super.init()
+    }
+
+    func start(deviceId: UUID?) {
         dispatchQueue.async {
-            self.cyclingSpeedCadence.setWheelCircumference(millimeters: wheelCircumference)
             self.startInternal(deviceId: deviceId)
         }
     }
@@ -155,15 +158,15 @@ extension WorkoutDevice: CBCentralManagerDelegate {
 
     private func handleCyclingPowerMeasurement(value: Data) throws {
         let (power, cadence) = try cyclingPower.handleMeasurement(value: value)
-        let ownedByCyclingSpeedCadence = cyclingSpeedCadence.isReportingCrankRevolutions()
+        let ownedByCyclingSpeedCadence = cyclingSpeedCadence.isReportingCadence()
         delegate?.workoutDeviceCyclingPower(self,
                                             power: power,
                                             cadence: ownedByCyclingSpeedCadence ? nil : cadence)
     }
 
     private func handleCyclingSpeedCadenceMeasurement(value: Data) throws {
-        let metrics = try cyclingSpeedCadence.handleMeasurement(value: value)
-        delegate?.workoutDeviceCyclingSpeedCadence(self, metrics: metrics)
+        let (speed, cadence) = try cyclingSpeedCadence.handleMeasurement(value: value)
+        delegate?.workoutDeviceCyclingSpeedCadence(self, speed: speed, cadence: cadence)
     }
 
     private func handleCyclingPowerVector(value: Data) throws {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -37,9 +37,9 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
     private var deviceId: UUID?
     weak var delegate: (any WorkoutDeviceDelegate)?
 
-    func start(deviceId: UUID?, wheelCircumferenceMillimeters: Int) {
+    func start(deviceId: UUID?, wheelCircumference: Int) {
         dispatchQueue.async {
-            self.cyclingSpeedCadence.setWheelCircumference(millimeters: wheelCircumferenceMillimeters)
+            self.cyclingSpeedCadence.setWheelCircumference(millimeters: wheelCircumference)
             self.startInternal(deviceId: deviceId)
         }
     }
@@ -58,10 +58,6 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
 
     func getState() -> WorkoutDeviceState {
         state
-    }
-
-    func isCyclingSpeedCadenceDiscovered() -> Bool {
-        cyclingSpeedCadence.isAnyCharacteristicDiscovered()
     }
 
     private func startInternal(deviceId: UUID?) {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -6,13 +6,16 @@ private let dispatchQueue = DispatchQueue(label: "com.eerimoq.workout-device")
 nonisolated(unsafe) let workoutDeviceScanner = BluetoothScanner(serviceIds: [
     workoutDeviceHeartRateServiceId,
     workoutDeviceCyclingPowerServiceId,
+    workoutDeviceCyclingSpeedCadenceServiceId,
     workoutDeviceRunningServiceId,
 ])
 
 protocol WorkoutDeviceDelegate: AnyObject {
     func workoutDeviceState(_ device: WorkoutDevice, state: WorkoutDeviceState)
     func workoutDeviceHeartRate(_ device: WorkoutDevice, heartRate: Int)
-    func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int)
+    func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int?)
+    func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice,
+                                          metrics: WorkoutDeviceCyclingSpeedCadenceMetrics)
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics)
 }
 
@@ -29,13 +32,21 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
     private var peripheral: CBPeripheral?
     private let heartRate = WorkoutDeviceHeartRate()
     private let cyclingPower = WorkoutDeviceCyclingPower()
+    private let cyclingSpeedCadence = WorkoutDeviceCyclingSpeedCadence()
     private let running = WorkoutDeviceRunning()
     private var deviceId: UUID?
     weak var delegate: (any WorkoutDeviceDelegate)?
 
-    func start(deviceId: UUID?) {
+    func start(deviceId: UUID?, wheelCircumferenceMillimeters: Int) {
         dispatchQueue.async {
+            self.cyclingSpeedCadence.setWheelCircumference(millimeters: wheelCircumferenceMillimeters)
             self.startInternal(deviceId: deviceId)
+        }
+    }
+
+    func setWheelCircumference(millimeters: Int) {
+        dispatchQueue.async {
+            self.cyclingSpeedCadence.setWheelCircumference(millimeters: millimeters)
         }
     }
 
@@ -64,6 +75,7 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
         peripheral = nil
         heartRate.reset()
         cyclingPower.reset()
+        cyclingSpeedCadence.reset()
         running.reset()
         setState(state: .disconnected)
     }
@@ -128,6 +140,9 @@ extension WorkoutDevice: CBCentralManagerDelegate {
         if cyclingPower.isAnyCharacteristicDiscovered() {
             return true
         }
+        if cyclingSpeedCadence.isAnyCharacteristicDiscovered() {
+            return true
+        }
         if running.isAnyCharacteristicDiscovered() {
             return true
         }
@@ -140,7 +155,15 @@ extension WorkoutDevice: CBCentralManagerDelegate {
 
     private func handleCyclingPowerMeasurement(value: Data) throws {
         let (power, cadence) = try cyclingPower.handleMeasurement(value: value)
-        delegate?.workoutDeviceCyclingPower(self, power: power, cadence: cadence)
+        let ownedByCyclingSpeedCadence = cyclingSpeedCadence.isReportingCrankRevolutions()
+        delegate?.workoutDeviceCyclingPower(self,
+                                            power: power,
+                                            cadence: ownedByCyclingSpeedCadence ? nil : cadence)
+    }
+
+    private func handleCyclingSpeedCadenceMeasurement(value: Data) throws {
+        let metrics = try cyclingSpeedCadence.handleMeasurement(value: value)
+        delegate?.workoutDeviceCyclingSpeedCadence(self, metrics: metrics)
     }
 
     private func handleCyclingPowerVector(value: Data) throws {
@@ -164,6 +187,9 @@ extension WorkoutDevice: CBPeripheralDelegate {
         if let service = services.first(where: { $0.uuid == workoutDeviceCyclingPowerServiceId }) {
             peripheral.discoverCharacteristics(nil, for: service)
         }
+        if let service = services.first(where: { $0.uuid == workoutDeviceCyclingSpeedCadenceServiceId }) {
+            peripheral.discoverCharacteristics(nil, for: service)
+        }
         if let service = services.first(where: { $0.uuid == workoutDeviceRunningServiceId }) {
             peripheral.discoverCharacteristics(nil, for: service)
         }
@@ -181,6 +207,9 @@ extension WorkoutDevice: CBPeripheralDelegate {
                 peripheral?.setNotifyValue(true, for: characteristic)
             case workoutDeviceCyclingPowerMeasurementCharacteristicId:
                 cyclingPower.setMeasurementCharacteristic(characteristic)
+                peripheral?.setNotifyValue(true, for: characteristic)
+            case workoutDeviceCyclingSpeedCadenceMeasurementCharacteristicId:
+                cyclingSpeedCadence.setMeasurementCharacteristic(characteristic)
                 peripheral?.setNotifyValue(true, for: characteristic)
             case workoutDeviceRunningMeasurementCharacteristicId:
                 running.setMeasurementCharacteristic(characteristic)
@@ -210,6 +239,8 @@ extension WorkoutDevice: CBPeripheralDelegate {
                 try handleCyclingPowerMeasurement(value: value)
             case workoutDeviceCyclingPowerVectorCharacteristicId:
                 try handleCyclingPowerVector(value: value)
+            case workoutDeviceCyclingSpeedCadenceMeasurementCharacteristicId:
+                try handleCyclingSpeedCadenceMeasurement(value: value)
             case workoutDeviceRunningMeasurementCharacteristicId:
                 try handleRunningMeasurement(value: value)
             default:

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -13,7 +13,7 @@ nonisolated(unsafe) let workoutDeviceScanner = BluetoothScanner(serviceIds: [
 protocol WorkoutDeviceDelegate: AnyObject {
     func workoutDeviceState(_ device: WorkoutDevice, state: WorkoutDeviceState)
     func workoutDeviceHeartRate(_ device: WorkoutDevice, heartRate: Int)
-    func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int?)
+    func workoutDeviceCyclingPower(_ device: WorkoutDevice, power: Int, cadence: Int)
     func workoutDeviceCyclingSpeedCadence(_ device: WorkoutDevice, speed: Double?, cadence: Int?)
     func workoutDeviceRunningMetrics(_ device: WorkoutDevice, metrics: WorkoutDeviceRunningMetrics)
 }
@@ -158,10 +158,7 @@ extension WorkoutDevice: CBCentralManagerDelegate {
 
     private func handleCyclingPowerMeasurement(value: Data) throws {
         let (power, cadence) = try cyclingPower.handleMeasurement(value: value)
-        let ownedByCyclingSpeedCadence = cyclingSpeedCadence.isReportingCadence()
-        delegate?.workoutDeviceCyclingPower(self,
-                                            power: power,
-                                            cadence: ownedByCyclingSpeedCadence ? nil : cadence)
+        delegate?.workoutDeviceCyclingPower(self, power: power, cadence: cadence)
     }
 
     private func handleCyclingSpeedCadenceMeasurement(value: Data) throws {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDevice.swift
@@ -60,6 +60,10 @@ class WorkoutDevice: NSObject, @unchecked Sendable {
         state
     }
 
+    func isCyclingSpeedCadenceDiscovered() -> Bool {
+        cyclingSpeedCadence.isAnyCharacteristicDiscovered()
+    }
+
     private func startInternal(deviceId: UUID?) {
         self.deviceId = deviceId
         reset()

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCrankCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCrankCadence.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+private let averageSampleCount = 3
+
+class WorkoutDeviceAverageCalculator {
+    private var values = Array(repeating: 0.0, count: averageSampleCount)
+    private var nextIndex = 0
+
+    func reset() {
+        values = Array(repeating: 0.0, count: averageSampleCount)
+        nextIndex = 0
+    }
+
+    func update(value: Double) {
+        values[nextIndex] = value
+        nextIndex += 1
+        nextIndex %= averageSampleCount
+    }
+
+    func average() -> Double {
+        values.reduce(0, +) / Double(averageSampleCount)
+    }
+
+    func averageIgnoreZeros() -> Double {
+        let nonZeroValues = values.filter { $0 != 0 }
+        guard !nonZeroValues.isEmpty else {
+            return 0
+        }
+        return nonZeroValues.reduce(0, +) / Double(nonZeroValues.count)
+    }
+}
+
+class WorkoutDeviceCrankCadence {
+    private var previousRevolutions: UInt16?
+    private var previousRevolutionsTime: UInt16?
+    private let averageCadence = WorkoutDeviceAverageCalculator()
+    private var latestAverageCadenceUpdateTime = ContinuousClock.now
+
+    func reset() {
+        previousRevolutions = nil
+        previousRevolutionsTime = nil
+        averageCadence.reset()
+    }
+
+    func update(revolutions: UInt16?, time: UInt16?, now: ContinuousClock.Instant) -> Int {
+        var cadence = -1.0
+        if let revolutions, let time {
+            if let previousRevolutions, let previousRevolutionsTime {
+                var deltaRevolutions = Int(revolutions) - Int(previousRevolutions)
+                if deltaRevolutions < 0 {
+                    deltaRevolutions += 65536
+                }
+                var deltaTime = Int(time) - Int(previousRevolutionsTime)
+                if deltaTime < 0 {
+                    deltaTime += 65536
+                }
+                let deltaTimeSeconds = Double(deltaTime) / 1024
+                if deltaTimeSeconds > 0 {
+                    cadence = 60 * Double(deltaRevolutions) / deltaTimeSeconds
+                    cadence = min(cadence, 10000)
+                }
+            }
+            previousRevolutions = revolutions
+            previousRevolutionsTime = time
+        }
+        if cadence != -1.0 {
+            averageCadence.update(value: cadence)
+            latestAverageCadenceUpdateTime = now
+        } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
+            averageCadence.update(value: 0)
+        }
+        return Int(averageCadence.averageIgnoreZeros())
+    }
+}

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingPower.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingPower.swift
@@ -17,8 +17,6 @@ private let measurementTopDeadSpotAngleFlagIndex = 9
 private let measurementBottomDeadSpotAngleFlagIndex = 10
 private let measurementAccumulatedEnergyFlagIndex = 11
 
-private let averageSampleCount = 3
-
 private struct PowerMeasurement {
     var instantaneousPower: UInt16 = 0
     // periphery:ignore
@@ -146,41 +144,14 @@ private struct PowerVector {
     }
 }
 
-private class AverageMeasurementCalculator {
-    private var values = Array(repeating: 0, count: averageSampleCount)
-    private var nextIndex = 0
-
-    func update(value: Int) {
-        values[nextIndex] = value
-        nextIndex += 1
-        nextIndex %= averageSampleCount
-    }
-
-    func average() -> Int {
-        values.reduce(0, +) / averageSampleCount
-    }
-
-    func averageIngoreZeros() -> Int {
-        let numberOfNonZeroValues = values.filter { $0 != 0 }.count
-        guard numberOfNonZeroValues > 0 else {
-            return 0
-        }
-        return values.reduce(0, +) / numberOfNonZeroValues
-    }
-}
-
 class WorkoutDeviceCyclingPower {
     private var measurementCharacteristic: CBCharacteristic?
-    private var previousRevolutions: UInt16?
-    private var previousRevolutionsTime: UInt16?
-    private var averagePower = AverageMeasurementCalculator()
-    private var averageCadence = AverageMeasurementCalculator()
-    private var latestAverageCadenceUpdateTime = ContinuousClock.now
+    private let averagePower = WorkoutDeviceAverageCalculator()
+    private let crankCadence = WorkoutDeviceCrankCadence()
 
     func reset() {
         measurementCharacteristic = nil
-        previousRevolutions = nil
-        previousRevolutionsTime = nil
+        crankCadence.reset()
     }
 
     func setMeasurementCharacteristic(_ characteristic: CBCharacteristic) {
@@ -193,37 +164,11 @@ class WorkoutDeviceCyclingPower {
 
     func handleMeasurement(value: Data) throws -> (Int, Int) {
         let measurement = try PowerMeasurement(value: value)
-        var cadence = -1.0
-        if let revolutions = measurement.cumulativeCrankRevolutions,
-           let time = measurement.lastCrankEventTime
-        {
-            if let previousRevolutions, let previousRevolutionsTime {
-                var deltaRevolutions = Int(revolutions) - Int(previousRevolutions)
-                if deltaRevolutions < 0 {
-                    deltaRevolutions += 65536
-                }
-                var deltaTime = Int(time) - Int(previousRevolutionsTime)
-                if deltaTime < 0 {
-                    deltaTime += 65536
-                }
-                let deltaTimeSeconds = Double(deltaTime) / 1024
-                if deltaTimeSeconds > 0 {
-                    cadence = 60 * Double(deltaRevolutions) / deltaTimeSeconds
-                    cadence = min(cadence, 10000)
-                }
-            }
-            previousRevolutions = revolutions
-            previousRevolutionsTime = time
-        }
-        averagePower.update(value: Int(measurement.instantaneousPower))
-        let now = ContinuousClock.now
-        if cadence != -1.0 {
-            averageCadence.update(value: Int(cadence))
-            latestAverageCadenceUpdateTime = now
-        } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
-            averageCadence.update(value: 0)
-        }
-        return (averagePower.average(), averageCadence.averageIngoreZeros())
+        averagePower.update(value: Double(measurement.instantaneousPower))
+        let cadence = crankCadence.update(revolutions: measurement.cumulativeCrankRevolutions,
+                                          time: measurement.lastCrankEventTime,
+                                          now: .now)
+        return (Int(averagePower.average()), cadence)
     }
 
     func handlePowerVector(value: Data) throws {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -64,10 +64,6 @@ class WorkoutDeviceCyclingSpeedCadence {
         wheelCircumferenceMeters = Double(millimeters) / 1000
     }
 
-    func isReportingCadence() -> Bool {
-        reportsCadence
-    }
-
     func handleMeasurement(value: Data) throws -> (Double?, Int?) {
         let measurement = try CyclingSpeedCadenceMeasurement(value: value)
         let now = ContinuousClock.now

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -4,12 +4,10 @@ import Foundation
 let workoutDeviceCyclingSpeedCadenceServiceId = CBUUID(string: "1816")
 let workoutDeviceCyclingSpeedCadenceMeasurementCharacteristicId = CBUUID(string: "2A5B")
 
-let defaultWheelCircumferenceMillimeters = 2105
+let defaultWheelCircumference = 2105
 
 private let measurementWheelRevolutionDataFlagIndex = 0
 private let measurementCrankRevolutionDataFlagIndex = 1
-
-private let averageSampleCount = 3
 
 struct WorkoutDeviceCyclingSpeedCadenceMetrics {
     var speed: Double?
@@ -36,51 +34,22 @@ private struct CyclingSpeedCadenceMeasurement {
     }
 }
 
-private class AverageMeasurementCalculator {
-    private var values = Array(repeating: 0.0, count: averageSampleCount)
-    private var nextIndex = 0
-
-    func reset() {
-        values = Array(repeating: 0.0, count: averageSampleCount)
-        nextIndex = 0
-    }
-
-    func update(value: Double) {
-        values[nextIndex] = value
-        nextIndex += 1
-        nextIndex %= averageSampleCount
-    }
-
-    func averageIgnoreZeros() -> Double {
-        let nonZeroValues = values.filter { $0 != 0 }
-        guard !nonZeroValues.isEmpty else {
-            return 0
-        }
-        return nonZeroValues.reduce(0, +) / Double(nonZeroValues.count)
-    }
-}
-
 class WorkoutDeviceCyclingSpeedCadence {
     private var measurementCharacteristic: CBCharacteristic?
-    private var previousCrankRevolutions: UInt16?
-    private var previousCrankRevolutionsTime: UInt16?
     private var previousWheelRevolutions: UInt32?
     private var previousWheelRevolutionsTime: UInt16?
-    private var averageCadence = AverageMeasurementCalculator()
-    private var averageSpeed = AverageMeasurementCalculator()
-    private var latestAverageCadenceUpdateTime = ContinuousClock.now
+    private let crankCadence = WorkoutDeviceCrankCadence()
+    private let averageSpeed = WorkoutDeviceAverageCalculator()
     private var latestAverageSpeedUpdateTime = ContinuousClock.now
     private var reportsCrankRevolutions = false
     private var reportsWheelRevolutions = false
-    private var wheelCircumferenceMeters = Double(defaultWheelCircumferenceMillimeters) / 1000
+    private var wheelCircumferenceMeters = Double(defaultWheelCircumference) / 1000
 
     func reset() {
         measurementCharacteristic = nil
-        previousCrankRevolutions = nil
-        previousCrankRevolutionsTime = nil
         previousWheelRevolutions = nil
         previousWheelRevolutionsTime = nil
-        averageCadence.reset()
+        crankCadence.reset()
         averageSpeed.reset()
         reportsCrankRevolutions = false
         reportsWheelRevolutions = false
@@ -105,44 +74,17 @@ class WorkoutDeviceCyclingSpeedCadence {
     func handleMeasurement(value: Data) throws -> WorkoutDeviceCyclingSpeedCadenceMetrics {
         let measurement = try CyclingSpeedCadenceMeasurement(value: value)
         let now = ContinuousClock.now
-        updateCadence(measurement: measurement, now: now)
+        if measurement.cumulativeCrankRevolutions != nil {
+            reportsCrankRevolutions = true
+        }
+        let cadence = crankCadence.update(revolutions: measurement.cumulativeCrankRevolutions,
+                                          time: measurement.lastCrankEventTime,
+                                          now: now)
         updateSpeed(measurement: measurement, now: now)
         return WorkoutDeviceCyclingSpeedCadenceMetrics(
             speed: reportsWheelRevolutions ? averageSpeed.averageIgnoreZeros() : nil,
-            cadence: reportsCrankRevolutions ? Int(averageCadence.averageIgnoreZeros()) : nil
+            cadence: reportsCrankRevolutions ? cadence : nil
         )
-    }
-
-    private func updateCadence(measurement: CyclingSpeedCadenceMeasurement, now: ContinuousClock.Instant) {
-        var cadence = -1.0
-        if let revolutions = measurement.cumulativeCrankRevolutions,
-           let time = measurement.lastCrankEventTime
-        {
-            reportsCrankRevolutions = true
-            if let previousCrankRevolutions, let previousCrankRevolutionsTime {
-                var deltaRevolutions = Int(revolutions) - Int(previousCrankRevolutions)
-                if deltaRevolutions < 0 {
-                    deltaRevolutions += 65536
-                }
-                var deltaTime = Int(time) - Int(previousCrankRevolutionsTime)
-                if deltaTime < 0 {
-                    deltaTime += 65536
-                }
-                let deltaTimeSeconds = Double(deltaTime) / 1024
-                if deltaTimeSeconds > 0 {
-                    cadence = 60 * Double(deltaRevolutions) / deltaTimeSeconds
-                    cadence = min(cadence, 10000)
-                }
-            }
-            previousCrankRevolutions = revolutions
-            previousCrankRevolutionsTime = time
-        }
-        if cadence != -1.0 {
-            averageCadence.update(value: cadence)
-            latestAverageCadenceUpdateTime = now
-        } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
-            averageCadence.update(value: 0)
-        }
     }
 
     private func updateSpeed(measurement: CyclingSpeedCadenceMeasurement, now: ContinuousClock.Instant) {

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -1,0 +1,180 @@
+@preconcurrency import CoreBluetooth
+import Foundation
+
+let workoutDeviceCyclingSpeedCadenceServiceId = CBUUID(string: "1816")
+let workoutDeviceCyclingSpeedCadenceMeasurementCharacteristicId = CBUUID(string: "2A5B")
+
+let defaultWheelCircumferenceMillimeters = 2105
+
+private let measurementWheelRevolutionDataFlagIndex = 0
+private let measurementCrankRevolutionDataFlagIndex = 1
+
+private let averageSampleCount = 3
+
+struct WorkoutDeviceCyclingSpeedCadenceMetrics {
+    var speed: Double?
+    var cadence: Int?
+}
+
+private struct CyclingSpeedCadenceMeasurement {
+    var cumulativeWheelRevolutions: UInt32?
+    var lastWheelEventTime: UInt16?
+    var cumulativeCrankRevolutions: UInt16?
+    var lastCrankEventTime: UInt16?
+
+    init(value: Data) throws {
+        let reader = ByteReader(data: value)
+        let flags = try reader.readUInt8()
+        if flags.isBitSet(index: measurementWheelRevolutionDataFlagIndex) {
+            cumulativeWheelRevolutions = try reader.readUInt32Le()
+            lastWheelEventTime = try reader.readUInt16Le()
+        }
+        if flags.isBitSet(index: measurementCrankRevolutionDataFlagIndex) {
+            cumulativeCrankRevolutions = try reader.readUInt16Le()
+            lastCrankEventTime = try reader.readUInt16Le()
+        }
+    }
+}
+
+private class AverageMeasurementCalculator {
+    private var values = Array(repeating: 0.0, count: averageSampleCount)
+    private var nextIndex = 0
+
+    func reset() {
+        values = Array(repeating: 0.0, count: averageSampleCount)
+        nextIndex = 0
+    }
+
+    func update(value: Double) {
+        values[nextIndex] = value
+        nextIndex += 1
+        nextIndex %= averageSampleCount
+    }
+
+    func averageIgnoreZeros() -> Double {
+        let nonZeroValues = values.filter { $0 != 0 }
+        guard !nonZeroValues.isEmpty else {
+            return 0
+        }
+        return nonZeroValues.reduce(0, +) / Double(nonZeroValues.count)
+    }
+}
+
+class WorkoutDeviceCyclingSpeedCadence {
+    private var measurementCharacteristic: CBCharacteristic?
+    private var previousCrankRevolutions: UInt16?
+    private var previousCrankRevolutionsTime: UInt16?
+    private var previousWheelRevolutions: UInt32?
+    private var previousWheelRevolutionsTime: UInt16?
+    private var averageCadence = AverageMeasurementCalculator()
+    private var averageSpeed = AverageMeasurementCalculator()
+    private var latestAverageCadenceUpdateTime = ContinuousClock.now
+    private var latestAverageSpeedUpdateTime = ContinuousClock.now
+    private var reportsCrankRevolutions = false
+    private var reportsWheelRevolutions = false
+    private var wheelCircumferenceMeters = Double(defaultWheelCircumferenceMillimeters) / 1000
+
+    func reset() {
+        measurementCharacteristic = nil
+        previousCrankRevolutions = nil
+        previousCrankRevolutionsTime = nil
+        previousWheelRevolutions = nil
+        previousWheelRevolutionsTime = nil
+        averageCadence.reset()
+        averageSpeed.reset()
+        reportsCrankRevolutions = false
+        reportsWheelRevolutions = false
+    }
+
+    func setMeasurementCharacteristic(_ characteristic: CBCharacteristic) {
+        measurementCharacteristic = characteristic
+    }
+
+    func isAnyCharacteristicDiscovered() -> Bool {
+        measurementCharacteristic != nil
+    }
+
+    func setWheelCircumference(millimeters: Int) {
+        wheelCircumferenceMeters = Double(millimeters) / 1000
+    }
+
+    func isReportingCrankRevolutions() -> Bool {
+        reportsCrankRevolutions
+    }
+
+    func handleMeasurement(value: Data) throws -> WorkoutDeviceCyclingSpeedCadenceMetrics {
+        let measurement = try CyclingSpeedCadenceMeasurement(value: value)
+        let now = ContinuousClock.now
+        updateCadence(measurement: measurement, now: now)
+        updateSpeed(measurement: measurement, now: now)
+        return WorkoutDeviceCyclingSpeedCadenceMetrics(
+            speed: reportsWheelRevolutions ? averageSpeed.averageIgnoreZeros() : nil,
+            cadence: reportsCrankRevolutions ? Int(averageCadence.averageIgnoreZeros()) : nil
+        )
+    }
+
+    private func updateCadence(measurement: CyclingSpeedCadenceMeasurement, now: ContinuousClock.Instant) {
+        var cadence = -1.0
+        if let revolutions = measurement.cumulativeCrankRevolutions,
+           let time = measurement.lastCrankEventTime
+        {
+            reportsCrankRevolutions = true
+            if let previousCrankRevolutions, let previousCrankRevolutionsTime {
+                var deltaRevolutions = Int(revolutions) - Int(previousCrankRevolutions)
+                if deltaRevolutions < 0 {
+                    deltaRevolutions += 65536
+                }
+                var deltaTime = Int(time) - Int(previousCrankRevolutionsTime)
+                if deltaTime < 0 {
+                    deltaTime += 65536
+                }
+                let deltaTimeSeconds = Double(deltaTime) / 1024
+                if deltaTimeSeconds > 0 {
+                    cadence = 60 * Double(deltaRevolutions) / deltaTimeSeconds
+                    cadence = min(cadence, 10000)
+                }
+            }
+            previousCrankRevolutions = revolutions
+            previousCrankRevolutionsTime = time
+        }
+        if cadence != -1.0 {
+            averageCadence.update(value: cadence)
+            latestAverageCadenceUpdateTime = now
+        } else if latestAverageCadenceUpdateTime.duration(to: now) > .seconds(3) {
+            averageCadence.update(value: 0)
+        }
+    }
+
+    private func updateSpeed(measurement: CyclingSpeedCadenceMeasurement, now: ContinuousClock.Instant) {
+        var speed = -1.0
+        if let revolutions = measurement.cumulativeWheelRevolutions,
+           let time = measurement.lastWheelEventTime
+        {
+            reportsWheelRevolutions = true
+            if let previousWheelRevolutions, let previousWheelRevolutionsTime {
+                var deltaRevolutions = Int(revolutions) - Int(previousWheelRevolutions)
+                if deltaRevolutions < 0 {
+                    deltaRevolutions += 4_294_967_296
+                }
+                deltaRevolutions = min(deltaRevolutions, 1000)
+                var deltaTime = Int(time) - Int(previousWheelRevolutionsTime)
+                if deltaTime < 0 {
+                    deltaTime += 65536
+                }
+                let deltaTimeSeconds = Double(deltaTime) / 1024
+                if deltaTimeSeconds > 0 {
+                    speed = Double(deltaRevolutions) * wheelCircumferenceMeters / deltaTimeSeconds
+                    speed = min(speed, 100)
+                }
+            }
+            previousWheelRevolutions = revolutions
+            previousWheelRevolutionsTime = time
+        }
+        if speed != -1.0 {
+            averageSpeed.update(value: speed)
+            latestAverageSpeedUpdateTime = now
+        } else if latestAverageSpeedUpdateTime.duration(to: now) > .seconds(3) {
+            averageSpeed.update(value: 0)
+        }
+    }
+}

--- a/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
+++ b/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadence.swift
@@ -4,15 +4,8 @@ import Foundation
 let workoutDeviceCyclingSpeedCadenceServiceId = CBUUID(string: "1816")
 let workoutDeviceCyclingSpeedCadenceMeasurementCharacteristicId = CBUUID(string: "2A5B")
 
-let defaultWheelCircumference = 2105
-
 private let measurementWheelRevolutionDataFlagIndex = 0
 private let measurementCrankRevolutionDataFlagIndex = 1
-
-struct WorkoutDeviceCyclingSpeedCadenceMetrics {
-    var speed: Double?
-    var cadence: Int?
-}
 
 private struct CyclingSpeedCadenceMeasurement {
     var cumulativeWheelRevolutions: UInt32?
@@ -41,9 +34,13 @@ class WorkoutDeviceCyclingSpeedCadence {
     private let crankCadence = WorkoutDeviceCrankCadence()
     private let averageSpeed = WorkoutDeviceAverageCalculator()
     private var latestAverageSpeedUpdateTime = ContinuousClock.now
-    private var reportsCrankRevolutions = false
+    private var reportsCadence = false
     private var reportsWheelRevolutions = false
-    private var wheelCircumferenceMeters = Double(defaultWheelCircumference) / 1000
+    private var wheelCircumferenceMeters: Double
+
+    init(wheelCircumference: Int) {
+        wheelCircumferenceMeters = Double(wheelCircumference) / 1000
+    }
 
     func reset() {
         measurementCharacteristic = nil
@@ -51,7 +48,7 @@ class WorkoutDeviceCyclingSpeedCadence {
         previousWheelRevolutionsTime = nil
         crankCadence.reset()
         averageSpeed.reset()
-        reportsCrankRevolutions = false
+        reportsCadence = false
         reportsWheelRevolutions = false
     }
 
@@ -67,24 +64,22 @@ class WorkoutDeviceCyclingSpeedCadence {
         wheelCircumferenceMeters = Double(millimeters) / 1000
     }
 
-    func isReportingCrankRevolutions() -> Bool {
-        reportsCrankRevolutions
+    func isReportingCadence() -> Bool {
+        reportsCadence
     }
 
-    func handleMeasurement(value: Data) throws -> WorkoutDeviceCyclingSpeedCadenceMetrics {
+    func handleMeasurement(value: Data) throws -> (Double?, Int?) {
         let measurement = try CyclingSpeedCadenceMeasurement(value: value)
         let now = ContinuousClock.now
         if measurement.cumulativeCrankRevolutions != nil {
-            reportsCrankRevolutions = true
+            reportsCadence = true
         }
         let cadence = crankCadence.update(revolutions: measurement.cumulativeCrankRevolutions,
                                           time: measurement.lastCrankEventTime,
                                           now: now)
         updateSpeed(measurement: measurement, now: now)
-        return WorkoutDeviceCyclingSpeedCadenceMetrics(
-            speed: reportsWheelRevolutions ? averageSpeed.averageIgnoreZeros() : nil,
-            cadence: reportsCrankRevolutions ? cadence : nil
-        )
+        return (reportsWheelRevolutions ? averageSpeed.averageIgnoreZeros() : nil,
+                reportsCadence ? cadence : nil)
     }
 
     private func updateSpeed(measurement: CyclingSpeedCadenceMeasurement, now: ContinuousClock.Instant) {

--- a/Moblin/RemoteControl/RemoteControl.swift
+++ b/Moblin/RemoteControl/RemoteControl.swift
@@ -131,6 +131,7 @@ struct RemoteControlStats: Codable {
     var stepCount: Int?
     var cyclingPower: Int
     var cyclingCadence: Int
+    var cyclingSpeed: Double
     var gForce: GForce?
 }
 
@@ -654,6 +655,7 @@ struct RemoteControlRemoteSceneDataVariables: Codable {
     let teslaMedia: String
     let cyclingPower: String
     let cyclingCadence: String
+    let cyclingSpeed: Double
     let runningMetrics: [String: WorkoutDeviceRunningMetrics]
     let browserTitle: String
     let gForce: GForce?
@@ -702,6 +704,7 @@ struct RemoteControlRemoteSceneDataVariables: Codable {
         teslaMedia = variables.teslaMedia
         cyclingPower = variables.cyclingPower
         cyclingCadence = variables.cyclingCadence
+        cyclingSpeed = variables.cyclingSpeed
         runningMetrics = variables.runningMetrics
         browserTitle = variables.browserTitle
         gForce = variables.gForce
@@ -752,6 +755,7 @@ struct RemoteControlRemoteSceneDataVariables: Codable {
                   teslaMedia: teslaMedia,
                   cyclingPower: cyclingPower,
                   cyclingCadence: cyclingCadence,
+                  cyclingSpeed: cyclingSpeed,
                   runningMetrics: runningMetrics,
                   browserTitle: browserTitle,
                   gForce: gForce,

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -671,6 +671,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     var catPrinters: [UUID: CatPrinter] = [:]
     var cyclingPower = 0
     var cyclingCadence = 0
+    var latestCyclingSpeedCadenceCadenceTime: ContinuousClock.Instant?
     var cyclingSpeed = 0.0
     var latestSubscriber = ""
     var latestFollower = ""

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -671,6 +671,7 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
     var catPrinters: [UUID: CatPrinter] = [:]
     var cyclingPower = 0
     var cyclingCadence = 0
+    var cyclingSpeed = 0.0
     var latestSubscriber = ""
     var latestFollower = ""
     private let periodicTimer20ms = SimpleTimer(queue: .main)

--- a/Moblin/Various/Model/ModelRemoteControl.swift
+++ b/Moblin/Various/Model/ModelRemoteControl.swift
@@ -576,6 +576,7 @@ extension Model {
             stepCount: workoutStepCount,
             cyclingPower: cyclingPower,
             cyclingCadence: cyclingCadence,
+            cyclingSpeed: cyclingSpeed,
             gForce: gForceManager?.getLatest()
         ))
     }

--- a/Moblin/Various/Model/ModelVariables.swift
+++ b/Moblin/Various/Model/ModelVariables.swift
@@ -47,6 +47,7 @@ extension Model {
             teslaMedia: textEffectTeslaMedia(),
             cyclingPower: "\(cyclingPower) W",
             cyclingCadence: "\(cyclingCadence)",
+            cyclingSpeed: cyclingSpeed,
             runningMetrics: runningMetrics,
             browserTitle: getBrowserTitle(),
             gForce: gForceManager?.getLatest(),

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -37,6 +37,10 @@ extension Model {
         workoutDevices[device.id]?.getState() ?? .disconnected
     }
 
+    func isWorkoutDeviceCyclingSpeedCadence(device: SettingsWorkoutDevice) -> Bool {
+        workoutDevices[device.id]?.isCyclingSpeedCadenceDiscovered() ?? false
+    }
+
     func autoStartWorkoutDevices() {
         for device in database.workoutDevices.devices where device.enabled {
             enableWorkoutDevice(device: device)

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -56,6 +56,13 @@ extension Model {
             getWorkoutDeviceSettings(device: $0)?.enabled == true && $0.getState() != .connected
         })
     }
+
+    private func isCyclingSpeedCadenceReportingCadence() -> Bool {
+        guard let latestCyclingSpeedCadenceCadenceTime else {
+            return false
+        }
+        return latestCyclingSpeedCadenceCadenceTime.duration(to: .now) < .seconds(5)
+    }
 }
 
 extension Model: @preconcurrency WorkoutDeviceDelegate {
@@ -82,10 +89,10 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         }
     }
 
-    func workoutDeviceCyclingPower(_: WorkoutDevice, power: Int, cadence: Int?) {
+    func workoutDeviceCyclingPower(_: WorkoutDevice, power: Int, cadence: Int) {
         DispatchQueue.main.async {
             self.cyclingPower = power
-            if let cadence {
+            if !self.isCyclingSpeedCadenceReportingCadence() {
                 self.cyclingCadence = cadence
             }
         }
@@ -95,6 +102,7 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         DispatchQueue.main.async {
             if let cadence {
                 self.cyclingCadence = cadence
+                self.latestCyclingSpeedCadenceCadenceTime = .now
             }
             if let speed {
                 self.cyclingSpeed = speed

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -7,12 +7,11 @@ extension Model {
 
     func enableWorkoutDevice(device: SettingsWorkoutDevice) {
         if !workoutDevices.keys.contains(device.id) {
-            let workoutDevice = WorkoutDevice()
+            let workoutDevice = WorkoutDevice(wheelCircumference: device.wheelCircumference)
             workoutDevice.delegate = self
             workoutDevices[device.id] = workoutDevice
         }
-        workoutDevices[device.id]?.start(deviceId: device.bluetoothPeripheralId,
-                                         wheelCircumference: device.wheelCircumference)
+        workoutDevices[device.id]?.start(deviceId: device.bluetoothPeripheralId)
     }
 
     func disableWorkoutDevice(device: SettingsWorkoutDevice) {
@@ -92,14 +91,12 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         }
     }
 
-    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice,
-                                          metrics: WorkoutDeviceCyclingSpeedCadenceMetrics)
-    {
+    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice, speed: Double?, cadence: Int?) {
         DispatchQueue.main.async {
-            if let cadence = metrics.cadence {
+            if let cadence {
                 self.cyclingCadence = cadence
             }
-            if let speed = metrics.speed {
+            if let speed {
                 self.cyclingSpeed = speed
             }
         }

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -11,7 +11,9 @@ extension Model {
             workoutDevice.delegate = self
             workoutDevices[device.id] = workoutDevice
         }
-        workoutDevices[device.id]?.start(deviceId: device.bluetoothPeripheralId)
+        let wheelCircumference = device.wheelCircumferenceMillimeters
+        workoutDevices[device.id]?.start(deviceId: device.bluetoothPeripheralId,
+                                         wheelCircumferenceMillimeters: wheelCircumference)
     }
 
     func disableWorkoutDevice(device: SettingsWorkoutDevice) {
@@ -20,6 +22,10 @@ extension Model {
 
     private func getWorkoutDeviceSettings(device: WorkoutDevice) -> SettingsWorkoutDevice? {
         database.workoutDevices.devices.first(where: { workoutDevices[$0.id] === device })
+    }
+
+    func setWorkoutDeviceWheelCircumference(device: SettingsWorkoutDevice) {
+        workoutDevices[device.id]?.setWheelCircumference(millimeters: device.wheelCircumferenceMillimeters)
     }
 
     func setCurrentWorkoutDevice(device: SettingsWorkoutDevice) {
@@ -78,10 +84,25 @@ extension Model: @preconcurrency WorkoutDeviceDelegate {
         }
     }
 
-    func workoutDeviceCyclingPower(_: WorkoutDevice, power: Int, cadence: Int) {
+    func workoutDeviceCyclingPower(_: WorkoutDevice, power: Int, cadence: Int?) {
         DispatchQueue.main.async {
             self.cyclingPower = power
-            self.cyclingCadence = cadence
+            if let cadence {
+                self.cyclingCadence = cadence
+            }
+        }
+    }
+
+    func workoutDeviceCyclingSpeedCadence(_: WorkoutDevice,
+                                          metrics: WorkoutDeviceCyclingSpeedCadenceMetrics)
+    {
+        DispatchQueue.main.async {
+            if let cadence = metrics.cadence {
+                self.cyclingCadence = cadence
+            }
+            if let speed = metrics.speed {
+                self.cyclingSpeed = speed
+            }
         }
     }
 

--- a/Moblin/Various/Model/ModelWorkoutDevice.swift
+++ b/Moblin/Various/Model/ModelWorkoutDevice.swift
@@ -11,9 +11,8 @@ extension Model {
             workoutDevice.delegate = self
             workoutDevices[device.id] = workoutDevice
         }
-        let wheelCircumference = device.wheelCircumferenceMillimeters
         workoutDevices[device.id]?.start(deviceId: device.bluetoothPeripheralId,
-                                         wheelCircumferenceMillimeters: wheelCircumference)
+                                         wheelCircumference: device.wheelCircumference)
     }
 
     func disableWorkoutDevice(device: SettingsWorkoutDevice) {
@@ -25,7 +24,7 @@ extension Model {
     }
 
     func setWorkoutDeviceWheelCircumference(device: SettingsWorkoutDevice) {
-        workoutDevices[device.id]?.setWheelCircumference(millimeters: device.wheelCircumferenceMillimeters)
+        workoutDevices[device.id]?.setWheelCircumference(millimeters: device.wheelCircumference)
     }
 
     func setCurrentWorkoutDevice(device: SettingsWorkoutDevice) {
@@ -35,10 +34,6 @@ extension Model {
 
     func getWorkoutDeviceState(device: SettingsWorkoutDevice) -> WorkoutDeviceState {
         workoutDevices[device.id]?.getState() ?? .disconnected
-    }
-
-    func isWorkoutDeviceCyclingSpeedCadence(device: SettingsWorkoutDevice) -> Bool {
-        workoutDevices[device.id]?.isCyclingSpeedCadenceDiscovered() ?? false
     }
 
     func autoStartWorkoutDevices() {

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -635,6 +635,8 @@ class SettingsCyclingPowerDevices: Codable, ObservableObject {
     }
 }
 
+let defaultWheelCircumference = 2105
+
 class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
     static let baseName = String(localized: "My device")
     var id: UUID = .init()

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -642,6 +642,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
     @Published var enabled: Bool = false
     @Published var bluetoothPeripheralName: String?
     @Published var bluetoothPeripheralId: UUID?
+    @Published var wheelCircumferenceMillimeters: Int = defaultWheelCircumferenceMillimeters
 
     enum CodingKeys: CodingKey {
         case id
@@ -649,6 +650,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         case enabled
         case bluetoothPeripheralName
         case bluetoothPeripheralId
+        case wheelCircumferenceMillimeters
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -658,6 +660,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.enabled, enabled)
         try container.encode(.bluetoothPeripheralName, bluetoothPeripheralName)
         try container.encode(.bluetoothPeripheralId, bluetoothPeripheralId)
+        try container.encode(.wheelCircumferenceMillimeters, wheelCircumferenceMillimeters)
     }
 
     init() {}
@@ -669,6 +672,9 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         enabled = container.decode(.enabled, Bool.self, false)
         bluetoothPeripheralName = try? container.decode(String.self, forKey: .bluetoothPeripheralName)
         bluetoothPeripheralId = try? container.decode(UUID.self, forKey: .bluetoothPeripheralId)
+        wheelCircumferenceMillimeters = container.decode(.wheelCircumferenceMillimeters,
+                                                         Int.self,
+                                                         defaultWheelCircumferenceMillimeters)
     }
 }
 

--- a/Moblin/Various/Settings/Settings.swift
+++ b/Moblin/Various/Settings/Settings.swift
@@ -642,7 +642,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
     @Published var enabled: Bool = false
     @Published var bluetoothPeripheralName: String?
     @Published var bluetoothPeripheralId: UUID?
-    @Published var wheelCircumferenceMillimeters: Int = defaultWheelCircumferenceMillimeters
+    @Published var wheelCircumference: Int = defaultWheelCircumference
 
     enum CodingKeys: CodingKey {
         case id
@@ -650,7 +650,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         case enabled
         case bluetoothPeripheralName
         case bluetoothPeripheralId
-        case wheelCircumferenceMillimeters
+        case wheelCircumference
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -660,7 +660,7 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         try container.encode(.enabled, enabled)
         try container.encode(.bluetoothPeripheralName, bluetoothPeripheralName)
         try container.encode(.bluetoothPeripheralId, bluetoothPeripheralId)
-        try container.encode(.wheelCircumferenceMillimeters, wheelCircumferenceMillimeters)
+        try container.encode(.wheelCircumference, wheelCircumference)
     }
 
     init() {}
@@ -672,9 +672,9 @@ class SettingsWorkoutDevice: Codable, Identifiable, ObservableObject, Named {
         enabled = container.decode(.enabled, Bool.self, false)
         bluetoothPeripheralName = try? container.decode(String.self, forKey: .bluetoothPeripheralName)
         bluetoothPeripheralId = try? container.decode(UUID.self, forKey: .bluetoothPeripheralId)
-        wheelCircumferenceMillimeters = container.decode(.wheelCircumferenceMillimeters,
-                                                         Int.self,
-                                                         defaultWheelCircumferenceMillimeters)
+        wheelCircumference = container.decode(.wheelCircumference,
+                                              Int.self,
+                                              defaultWheelCircumference)
     }
 }
 

--- a/Moblin/Various/Variables.swift
+++ b/Moblin/Various/Variables.swift
@@ -43,6 +43,7 @@ struct Variables {
     let teslaMedia: String
     let cyclingPower: String
     let cyclingCadence: String
+    let cyclingSpeed: Double
     let runningMetrics: [String: WorkoutDeviceRunningMetrics]
     let browserTitle: String
     let gForce: GForce?

--- a/Moblin/VideoEffects/Text/TextEffectFormatter.swift
+++ b/Moblin/VideoEffects/Text/TextEffectFormatter.swift
@@ -225,6 +225,8 @@ class TextEffectFormatter {
                 formatCyclingPower(variables: variables)
             case .cyclingCadence:
                 formatCyclingCadence(variables: variables)
+            case let .cyclingSpeed(unit):
+                formatCyclingSpeed(variables: variables, unit: unit)
             case let .runningPace(deviceName):
                 formatRunningPace(variables: variables, deviceName: deviceName)
             case let .runningCadence(deviceName):
@@ -544,6 +546,10 @@ class TextEffectFormatter {
         } else {
             appendTextPart(value: "-")
         }
+    }
+
+    private func formatCyclingSpeed(variables: Variables, unit: TextFormatSpeedUnit) {
+        appendTextPart(value: formatSpeed(speed: variables.cyclingSpeed, unit: unit))
     }
 
     private func formatRunningCadence(variables: Variables, deviceName: String) {

--- a/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
+++ b/Moblin/VideoEffects/Text/TextFormatStringLoader.swift
@@ -271,6 +271,7 @@ enum TextFormatPart: Equatable {
     case teslaMedia
     case cyclingPower
     case cyclingCadence
+    case cyclingSpeed(TextFormatSpeedUnit)
     case runningPace(String)
     case runningCadence(String)
     case runningDistance(String)
@@ -381,6 +382,7 @@ class TextFormatLoader {
                     loadItem(part: .cyclingPower, offsetBy: 14)
                 } else if formatFromIndex.hasPrefix("{cyclingcadence}") {
                     loadItem(part: .cyclingCadence, offsetBy: 16)
+                } else if appendCyclingSpeedIfPresent(formatFromIndex: formatFromIndex) {
                 } else if formatFromIndex.hasPrefix("{laptimes}") {
                     loadItem(part: .lapTimes, offsetBy: 10)
                 } else if formatFromIndex.hasPrefix("{browsertitle}") {
@@ -415,6 +417,13 @@ class TextFormatLoader {
                                "{speed}",
                                /{speed:([^}]+)}/,
                                TextFormatSpeedUnit.init) { .speed($0 ?? .system) }
+    }
+
+    private func appendCyclingSpeedIfPresent(formatFromIndex: String) -> Bool {
+        appendOptionsIfPresent(formatFromIndex,
+                               "{cyclingspeed}",
+                               /{cyclingspeed:([^}]+)}/,
+                               TextFormatSpeedUnit.init) { .cyclingSpeed($0 ?? .system) }
     }
 
     private func appendAverageSpeedIfPresent(formatFromIndex: String) -> Bool {

--- a/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
+++ b/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
@@ -9,6 +9,8 @@ struct Version {
 // swiftlint:disable line_length
 private let versions = [
     Version(version: "34.2138.0", date: "2026-09-06", changes: [
+        "• Support for cycling speed and cadence (CSC) sensors.",
+        "  • Shows up as workout devices. Use {cyclingCadence} and {cyclingSpeed} in text widget.",
         "• !moblin custom <name> to define custom chat bot commands. Define format string with variables, much like for the text widget. 💡 Crozbo",
         "• Make animated chat emotes use less CPU.",
         "• Make chat message border use less CPU.",

--- a/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
+++ b/Moblin/View/Settings/About/AboutVersionHistorySettingsView.swift
@@ -9,8 +9,6 @@ struct Version {
 // swiftlint:disable line_length
 private let versions = [
     Version(version: "34.2138.0", date: "2026-09-06", changes: [
-        "• Support for cycling speed and cadence (CSC) sensors.",
-        "  • Shows up as workout devices. Use {cyclingCadence} and {cyclingSpeed} in text widget.",
         "• !moblin custom <name> to define custom chat bot commands. Define format string with variables, much like for the text widget. 💡 Crozbo",
         "• Make animated chat emotes use less CPU.",
         "• Make chat message border use less CPU.",

--- a/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
+++ b/Moblin/View/Settings/Scenes/Widgets/Widget/Text/WidgetTextSettingsView.swift
@@ -1112,6 +1112,11 @@ private struct WorkoutVariablesView: View {
                         description: String(localized: "Show cycling cadence"),
                         text: $value
                     )
+                    VariableView(
+                        title: "{cyclingSpeed}",
+                        description: String(localized: "Show cycling speed"),
+                        text: $value
+                    )
                 }
             }
             .navigationTitle("Workout")

--- a/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
+++ b/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
@@ -29,6 +29,27 @@ struct WorkoutDeviceSettingsView: View {
         device.bluetoothPeripheralId != nil
     }
 
+    private func isValidWheelCircumference(value: String) -> String? {
+        guard let millimeters = Int(value) else {
+            return String(localized: "Not a number")
+        }
+        guard millimeters >= 500 else {
+            return String(localized: "Too small")
+        }
+        guard millimeters <= 3000 else {
+            return String(localized: "Too big")
+        }
+        return nil
+    }
+
+    private func submitWheelCircumference(value: String) {
+        guard let millimeters = Int(value) else {
+            return
+        }
+        device.wheelCircumferenceMillimeters = millimeters
+        model.setWorkoutDeviceWheelCircumference(device: device)
+    }
+
     private func onDeviceChange(value: String) {
         guard let deviceId = UUID(uuidString: value) else {
             return
@@ -75,6 +96,18 @@ struct WorkoutDeviceSettingsView: View {
                             }
                         }
                         .disabled(!canEnable())
+                }
+                Section {
+                    TextEditNavigationView(
+                        title: String(localized: "Wheel circumference"),
+                        value: String(device.wheelCircumferenceMillimeters),
+                        onChange: isValidWheelCircumference,
+                        onSubmit: submitWheelCircumference,
+                        keyboardType: .numbersAndPunctuation,
+                        valueFormat: { "\($0) mm" }
+                    )
+                } footer: {
+                    Text("Used to calculate speed from cycling speed and cadence (CSC) sensors.")
                 }
                 if device.enabled {
                     Section {

--- a/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
+++ b/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
@@ -97,17 +97,19 @@ struct WorkoutDeviceSettingsView: View {
                         }
                         .disabled(!canEnable())
                 }
-                Section {
-                    TextEditNavigationView(
-                        title: String(localized: "Wheel circumference"),
-                        value: String(device.wheelCircumferenceMillimeters),
-                        onChange: isValidWheelCircumference,
-                        onSubmit: submitWheelCircumference,
-                        keyboardType: .numbersAndPunctuation,
-                        valueFormat: { "\($0) mm" }
-                    )
-                } footer: {
-                    Text("Used to calculate speed from cycling speed and cadence (CSC) sensors.")
+                if model.isWorkoutDeviceCyclingSpeedCadence(device: device) {
+                    Section {
+                        TextEditNavigationView(
+                            title: String(localized: "Wheel circumference"),
+                            value: String(device.wheelCircumferenceMillimeters),
+                            onChange: isValidWheelCircumference,
+                            onSubmit: submitWheelCircumference,
+                            keyboardType: .numbersAndPunctuation,
+                            valueFormat: { "\($0) mm" }
+                        )
+                    } footer: {
+                        Text("Used to calculate speed from wheel revolutions.")
+                    }
                 }
                 if device.enabled {
                     Section {

--- a/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
+++ b/Moblin/View/Settings/WorkoutDevices/WorkoutDeviceSettingsView.swift
@@ -46,7 +46,7 @@ struct WorkoutDeviceSettingsView: View {
         guard let millimeters = Int(value) else {
             return
         }
-        device.wheelCircumferenceMillimeters = millimeters
+        device.wheelCircumference = millimeters
         model.setWorkoutDeviceWheelCircumference(device: device)
     }
 
@@ -97,19 +97,17 @@ struct WorkoutDeviceSettingsView: View {
                         }
                         .disabled(!canEnable())
                 }
-                if model.isWorkoutDeviceCyclingSpeedCadence(device: device) {
-                    Section {
-                        TextEditNavigationView(
-                            title: String(localized: "Wheel circumference"),
-                            value: String(device.wheelCircumferenceMillimeters),
-                            onChange: isValidWheelCircumference,
-                            onSubmit: submitWheelCircumference,
-                            keyboardType: .numbersAndPunctuation,
-                            valueFormat: { "\($0) mm" }
-                        )
-                    } footer: {
-                        Text("Used to calculate speed from wheel revolutions.")
-                    }
+                Section {
+                    TextEditNavigationView(
+                        title: String(localized: "Wheel circumference"),
+                        value: String(device.wheelCircumference),
+                        onChange: isValidWheelCircumference,
+                        onSubmit: submitWheelCircumference,
+                        keyboardType: .numbersAndPunctuation,
+                        valueFormat: { "\($0) mm" }
+                    )
+                } footer: {
+                    Text("Used to calculate speed from wheel revolutions.")
                 }
                 if device.enabled {
                     Section {

--- a/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
+++ b/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
@@ -1,0 +1,128 @@
+import Foundation
+@testable import Moblin
+import Testing
+
+private func crankMeasurement(revolutions: UInt16, eventTime: UInt16) -> Data {
+    var data = Data([0x02])
+    data.append(contentsOf: withUnsafeBytes(of: revolutions.littleEndian) { Array($0) })
+    data.append(contentsOf: withUnsafeBytes(of: eventTime.littleEndian) { Array($0) })
+    return data
+}
+
+private func wheelMeasurement(revolutions: UInt32, eventTime: UInt16) -> Data {
+    var data = Data([0x01])
+    data.append(contentsOf: withUnsafeBytes(of: revolutions.littleEndian) { Array($0) })
+    data.append(contentsOf: withUnsafeBytes(of: eventTime.littleEndian) { Array($0) })
+    return data
+}
+
+private func wheelAndCrankMeasurement(wheelRevolutions: UInt32,
+                                      wheelEventTime: UInt16,
+                                      crankRevolutions: UInt16,
+                                      crankEventTime: UInt16) -> Data
+{
+    var data = Data([0x03])
+    data.append(contentsOf: withUnsafeBytes(of: wheelRevolutions.littleEndian) { Array($0) })
+    data.append(contentsOf: withUnsafeBytes(of: wheelEventTime.littleEndian) { Array($0) })
+    data.append(contentsOf: withUnsafeBytes(of: crankRevolutions.littleEndian) { Array($0) })
+    data.append(contentsOf: withUnsafeBytes(of: crankEventTime.littleEndian) { Array($0) })
+    return data
+}
+
+struct WorkoutDeviceCyclingSpeedCadenceSuite {
+    @Test
+    func firstMeasurementOnlySeedsState() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 10,
+                                                                           eventTime: 1024))
+        #expect(metrics.cadence == 0)
+        #expect(metrics.speed == nil)
+    }
+
+    @Test
+    func calculatesCadenceFromCrankRevolutions() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
+        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 13,
+                                                                           eventTime: 1024 + 2048))
+        #expect(metrics.cadence == 90)
+    }
+
+    @Test
+    func handlesCrankRevolutionsWrapAround() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 65535, eventTime: 65000))
+        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 0,
+                                                                           eventTime: 65000 &+ 1024))
+        #expect(metrics.cadence == 60)
+    }
+
+    @Test
+    func ignoresMeasurementWithoutTimeProgress() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
+        _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 11, eventTime: 1024 + 1024))
+        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
+                                                                           eventTime: 1024 + 1024))
+        #expect(metrics.cadence == 60)
+    }
+
+    @Test
+    func cadenceOnlySensorReportsNoSpeed() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
+        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
+                                                                           eventTime: 1024 + 1024))
+        #expect(metrics.cadence == 60)
+        #expect(metrics.speed == nil)
+        #expect(device.isReportingCrankRevolutions())
+    }
+
+    @Test
+    func speedOnlySensorReportsNoCadence() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        device.setWheelCircumference(millimeters: 2000)
+        _ = try device.handleMeasurement(value: wheelMeasurement(revolutions: 100, eventTime: 1024))
+        let metrics = try device.handleMeasurement(value: wheelMeasurement(revolutions: 105,
+                                                                           eventTime: 1024 + 1024))
+        #expect(metrics.cadence == nil)
+        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
+        #expect(!device.isReportingCrankRevolutions())
+    }
+
+    @Test
+    func calculatesSpeedAndCadenceFromCombinedMeasurement() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        device.setWheelCircumference(millimeters: 2000)
+        _ = try device.handleMeasurement(value: wheelAndCrankMeasurement(wheelRevolutions: 100,
+                                                                         wheelEventTime: 1024,
+                                                                         crankRevolutions: 10,
+                                                                         crankEventTime: 1024))
+        let metrics = try device.handleMeasurement(value: wheelAndCrankMeasurement(
+            wheelRevolutions: 105,
+            wheelEventTime: 1024 + 1024,
+            crankRevolutions: 11,
+            crankEventTime: 1024 + 1024
+        ))
+        #expect(metrics.cadence == 60)
+        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
+    }
+
+    @Test
+    func handlesWheelRevolutionsWrapAround() throws {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        device.setWheelCircumference(millimeters: 2000)
+        _ = try device.handleMeasurement(value: wheelMeasurement(revolutions: .max, eventTime: 1024))
+        let metrics = try device.handleMeasurement(value: wheelMeasurement(revolutions: 4,
+                                                                           eventTime: 1024 + 1024))
+        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
+    }
+
+    @Test
+    func rejectsTruncatedMeasurement() {
+        let device = WorkoutDeviceCyclingSpeedCadence()
+        #expect(throws: (any Error).self) {
+            try device.handleMeasurement(value: Data([0x02, 0x01]))
+        }
+    }
+}

--- a/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
+++ b/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
@@ -32,95 +32,95 @@ private func wheelAndCrankMeasurement(wheelRevolutions: UInt32,
 struct WorkoutDeviceCyclingSpeedCadenceSuite {
     @Test
     func firstMeasurementOnlySeedsState() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
-        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 10,
-                                                                           eventTime: 1024))
-        #expect(metrics.cadence == 0)
-        #expect(metrics.speed == nil)
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
+        let (speed, cadence) = try device.handleMeasurement(value: crankMeasurement(revolutions: 10,
+                                                                                    eventTime: 1024))
+        #expect(cadence == 0)
+        #expect(speed == nil)
     }
 
     @Test
     func calculatesCadenceFromCrankRevolutions() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
-        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 13,
-                                                                           eventTime: 1024 + 2048))
-        #expect(metrics.cadence == 90)
+        let (_, cadence) = try device.handleMeasurement(value: crankMeasurement(revolutions: 13,
+                                                                                eventTime: 1024 + 2048))
+        #expect(cadence == 90)
     }
 
     @Test
     func handlesCrankRevolutionsWrapAround() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 65535, eventTime: 65000))
-        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 0,
-                                                                           eventTime: 65000 &+ 1024))
-        #expect(metrics.cadence == 60)
+        let (_, cadence) = try device.handleMeasurement(value: crankMeasurement(revolutions: 0,
+                                                                                eventTime: 65000 &+ 1024))
+        #expect(cadence == 60)
     }
 
     @Test
     func ignoresMeasurementWithoutTimeProgress() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
         _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 11, eventTime: 1024 + 1024))
-        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
-                                                                           eventTime: 1024 + 1024))
-        #expect(metrics.cadence == 60)
+        let (_, cadence) = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
+                                                                                eventTime: 1024 + 1024))
+        #expect(cadence == 60)
     }
 
     @Test
     func cadenceOnlySensorReportsNoSpeed() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         _ = try device.handleMeasurement(value: crankMeasurement(revolutions: 10, eventTime: 1024))
-        let metrics = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
-                                                                           eventTime: 1024 + 1024))
-        #expect(metrics.cadence == 60)
-        #expect(metrics.speed == nil)
-        #expect(device.isReportingCrankRevolutions())
+        let (speed, cadence) = try device.handleMeasurement(value: crankMeasurement(revolutions: 11,
+                                                                                    eventTime: 1024 + 1024))
+        #expect(cadence == 60)
+        #expect(speed == nil)
+        #expect(device.isReportingCadence())
     }
 
     @Test
     func speedOnlySensorReportsNoCadence() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         device.setWheelCircumference(millimeters: 2000)
         _ = try device.handleMeasurement(value: wheelMeasurement(revolutions: 100, eventTime: 1024))
-        let metrics = try device.handleMeasurement(value: wheelMeasurement(revolutions: 105,
-                                                                           eventTime: 1024 + 1024))
-        #expect(metrics.cadence == nil)
-        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
-        #expect(!device.isReportingCrankRevolutions())
+        let (speed, cadence) = try device.handleMeasurement(value: wheelMeasurement(revolutions: 105,
+                                                                                    eventTime: 1024 + 1024))
+        #expect(cadence == nil)
+        #expect(try isEqual(#require(speed), 10, epsilon: 0.001))
+        #expect(!device.isReportingCadence())
     }
 
     @Test
     func calculatesSpeedAndCadenceFromCombinedMeasurement() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         device.setWheelCircumference(millimeters: 2000)
         _ = try device.handleMeasurement(value: wheelAndCrankMeasurement(wheelRevolutions: 100,
                                                                          wheelEventTime: 1024,
                                                                          crankRevolutions: 10,
                                                                          crankEventTime: 1024))
-        let metrics = try device.handleMeasurement(value: wheelAndCrankMeasurement(
+        let (speed, cadence) = try device.handleMeasurement(value: wheelAndCrankMeasurement(
             wheelRevolutions: 105,
             wheelEventTime: 1024 + 1024,
             crankRevolutions: 11,
             crankEventTime: 1024 + 1024
         ))
-        #expect(metrics.cadence == 60)
-        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
+        #expect(cadence == 60)
+        #expect(try isEqual(#require(speed), 10, epsilon: 0.001))
     }
 
     @Test
     func handlesWheelRevolutionsWrapAround() throws {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         device.setWheelCircumference(millimeters: 2000)
         _ = try device.handleMeasurement(value: wheelMeasurement(revolutions: .max, eventTime: 1024))
-        let metrics = try device.handleMeasurement(value: wheelMeasurement(revolutions: 4,
-                                                                           eventTime: 1024 + 1024))
-        #expect(try isEqual(#require(metrics.speed), 10, epsilon: 0.001))
+        let (speed, _) = try device.handleMeasurement(value: wheelMeasurement(revolutions: 4,
+                                                                              eventTime: 1024 + 1024))
+        #expect(try isEqual(#require(speed), 10, epsilon: 0.001))
     }
 
     @Test
     func rejectsTruncatedMeasurement() {
-        let device = WorkoutDeviceCyclingSpeedCadence()
+        let device = WorkoutDeviceCyclingSpeedCadence(wheelCircumference: 2105)
         #expect(throws: (any Error).self) {
             try device.handleMeasurement(value: Data([0x02, 0x01]))
         }

--- a/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
+++ b/MoblinTests/Moblin/Integrations/WorkoutDevice/WorkoutDeviceCyclingSpeedCadenceSuite.swift
@@ -75,7 +75,6 @@ struct WorkoutDeviceCyclingSpeedCadenceSuite {
                                                                                     eventTime: 1024 + 1024))
         #expect(cadence == 60)
         #expect(speed == nil)
-        #expect(device.isReportingCadence())
     }
 
     @Test
@@ -87,7 +86,6 @@ struct WorkoutDeviceCyclingSpeedCadenceSuite {
                                                                                     eventTime: 1024 + 1024))
         #expect(cadence == nil)
         #expect(try isEqual(#require(speed), 10, epsilon: 0.001))
-        #expect(!device.isReportingCadence())
     }
 
     @Test

--- a/MoblinTests/Moblin/RemoteControl/RemoteControlSuite.swift
+++ b/MoblinTests/Moblin/RemoteControl/RemoteControlSuite.swift
@@ -48,6 +48,7 @@ struct RemoteControlSuite {
           "countryFlag" : "🇸🇪",
           "cyclingCadence" : "90",
           "cyclingPower" : "250 W",
+          "cyclingSpeed" : 10,
           "date" : 745043166,
           "debugOverlayLines" : [
             "First line",
@@ -151,6 +152,7 @@ struct RemoteControlSuite {
           "countryFlag" : "🇸🇪",
           "cyclingCadence" : 90,
           "cyclingPower" : 250,
+          "cyclingSpeed" : 10,
           "date" : 745043166,
           "distance" : 1700.75,
           "feelsLikeTemperature" : 17,
@@ -219,6 +221,7 @@ struct RemoteControlSuite {
         #expect(decoded.stepCount == 8000)
         #expect(decoded.cyclingPower == 250)
         #expect(decoded.cyclingCadence == 90)
+        #expect(decoded.cyclingSpeed == 10)
         #expect(decoded.gForce?.now == 1.5)
         #expect(decoded.gForce?.recentMax == 2.5)
         #expect(decoded.gForce?.max == 3.5)
@@ -256,6 +259,7 @@ struct RemoteControlSuite {
                            stepCount: 8000,
                            cyclingPower: 250,
                            cyclingCadence: 90,
+                           cyclingSpeed: 10,
                            gForce: GForce(now: 1.5, recentMax: 2.5, max: 3.5))
     }
 
@@ -301,6 +305,7 @@ struct RemoteControlSuite {
                   teslaMedia: "Song",
                   cyclingPower: "250 W",
                   cyclingCadence: "90",
+                  cyclingSpeed: 10,
                   runningMetrics: ["Foot pod": .init(speed: 3.5, cadence: 180, distance: 4200)],
                   browserTitle: "Title",
                   gForce: GForce(now: 1.5, recentMax: 2.5, max: 3.5),

--- a/MoblinTests/Moblin/VideoEffects/Text/TextEffectSuite.swift
+++ b/MoblinTests/Moblin/VideoEffects/Text/TextEffectSuite.swift
@@ -378,6 +378,7 @@ struct TextEffectSuite {
                   teslaMedia: "",
                   cyclingPower: "",
                   cyclingCadence: "",
+                  cyclingSpeed: 0,
                   runningMetrics: [:],
                   browserTitle: "",
                   gForce: gForce,


### PR DESCRIPTION
## Why

Not everyone rides with power meter pedals, but plenty of people have a cheap cadence sensor clipped
to the crank. Those sensors use a Bluetooth profile Moblin does not support, so today they simply do
not appear when you scan — there is no way to get cadence on stream without a power meter. This adds
support for them.

The same profile also covers wheel-mounted speed sensors, so speed comes with it, worked out from
the wheel size you set for that device.

## Summary

Adds Bluetooth LE Cycling Speed and Cadence (CSC, service `0x1816`) support, so cadence-only and
speed+cadence sensors show up under Settings → Workout devices. Today cycling cadence is only
available as a side effect of a power meter (Cycling Power `0x1818`), which means the cheap
standalone sensors — Wahoo RPM, Garmin Cadence 2, Magene, Cycplus, most spin-bike sensors — are
invisible to Moblin: the scanner does not even filter for their service.

- CSC feeds the existing `{cyclingCadence}` variable.
- New `{cyclingSpeed}` variable, with the usual unit options (`{cyclingSpeed:km/h}`, `:mph`, `:m/s`).
- Per-device wheel circumference setting (default 2105 mm), used to derive speed from wheel
  revolutions.

This picks up where #419 left off — thanks @jk1rill for the original work. It is reworked against
the current tree (that PR predates `TextEffectStats` becoming `Variables`) and fixes three gaps:

1. **The wheel circumference was hardcoded.** It is now a per-device setting, applied live while
   connected, so speed is right for something other than a 700×25c wheel.
2. **Cadence could be published twice.** A single peripheral can expose both `0x1818` and `0x1816`,
   and `WorkoutDevice` subscribes to whichever services it discovers, so both parsers wrote
   `cyclingCadence`. The cycling power delegate now passes `cadence: Int?` and yields to CSC when
   CSC is reporting crank revolutions for that peripheral. That is recorded on *field presence*, not
   on a derived value, so the two never both publish while CSC is still waiting for its first delta.
3. **Cadence-only sensors reported a speed of zero.** Speed and cadence are each optional now and
   only reach the model when the sensor actually reports that field.

Robustness details, mirroring what `WorkoutDeviceCyclingPower` already does: 16-bit crank and 32-bit
wheel counter rollover, 1/1024 s event-time base with its own rollover, a zero time delta (duplicate
or retransmitted notification) is skipped rather than treated as a stop, a 3-sample rolling average,
decay to zero after 3 s without new revolution data, and clamps on both the wheel revolution delta
and the derived values.

## Test plan

Tested on an indoor trainer with two separate single-metric CSC sensors — one on the crank, one on
the wheel — plus a power meter and a heart rate strap.

- [x] Settings → Workout devices → add a device, scan, pair a CSC sensor
- [x] Confirm it reaches Connected
- [x] `{cyclingCadence}` in a text widget updates while pedalling and returns to 0 when stopping
- [x] `{cyclingSpeed}` updates from a wheel sensor
- [x] A cadence-only sensor shows cadence and a speed-only sensor shows speed, without either
      overwriting the other
- [x] Existing heart rate and cycling power devices still work alongside them
- [x] With a power meter and a CSC cadence sensor both connected, cadence stays steady

Unit tests: `WorkoutDeviceCyclingSpeedCadenceSuite` covers cadence and speed derivation, both
counter wrap-arounds, cadence-only and speed-only sensors, combined wheel+crank packets, a duplicate
notification with no time progress, and a truncated packet. The wheel-circumference arithmetic is
covered there too, since a trainer gives me nothing to measure derived speed against.

## Screenshots

**Two CSC sensors paired — one on the crank, one on the wheel — each reporting only its own metric** (was hand rolling front wheel)

<img width="1398" height="645" alt="speed" src="https://github.com/user-attachments/assets/5f0fc524-0597-4f50-a63a-211c20fb0f77" />

**Cadence stays steady with a power meter and a heart rate strap connected alongside**

<img width="1398" height="645" alt="BLE" src="https://github.com/user-attachments/assets/fa946af5-0f3f-4de8-bb3c-2c38771574b5" />

**The setup: an indoor trainer, which is why the speed and distance figures are low**

<img width="4284" height="5712" alt="bike" src="https://github.com/user-attachments/assets/c9835811-8b64-40ec-92bf-e7955b5fba96" />

## Attribution

Written by Claude under my direction. Tested by me on real hardware — an indoor trainer setup, not
an outdoor bike.

The Bluetooth parsing was additionally cross-checked against a working Cycling Speed and Cadence
implementation in my own [Virtual Cycling Trainer](https://apps.apple.com/us/app/virtual-cycling-trainer/id6752381425) app, which has been running against real sensors
for a while — the flag handling, the 1/1024 s event-time base, the counter rollover and the
stopped-versus-no-new-event distinction all match what that stack does.
