### PR TITLE
Add Moblink relay temperature reporting

### DIFF
--- a/Moblin/Moblink/MoblinkProtocol.swift
+++ b/Moblin/Moblink/MoblinkProtocol.swift
@@ -16,7 +16,7 @@ enum MoblinkRequest: Codable {
 
 enum MoblinkResponse: Codable {
     case startTunnel(port: UInt16)
-    case status(batteryPercentage: Int?, thermalState: MoblinkThermalState?)
+    case status(batteryPercentage: Int?, thermalState: MoblinkThermalState?, temperatureCelsius: Int?)
 }
 
 struct MoblinkAuthentication: Codable {

--- a/Moblin/Moblink/MoblinkRelay.swift
+++ b/Moblin/Moblink/MoblinkRelay.swift
@@ -240,7 +240,8 @@ private class Relay: NSObject, @unchecked Sendable {
                                 result: .ok,
                                 data: .status(
                                     batteryPercentage: batteryPercentage,
-                                    thermalState: thermalState
+                                    thermalState: thermalState,
+                                    temperatureCelsius: nil
                                 )))
     }
 

--- a/Moblin/Moblink/MoblinkStreamer.swift
+++ b/Moblin/Moblink/MoblinkStreamer.swift
@@ -29,6 +29,7 @@ private class Relay {
     var name = ""
     var batteryPercentage: Int?
     var thermalState: MoblinkThermalState?
+    var temperatureCelsius: Int?
     private var pingTimer = SimpleTimer(queue: .main)
     var pongReceived = true
 
@@ -88,11 +89,12 @@ private class Relay {
 
     func updateStatus() {
         performRequest(data: .status) { response in
-            guard case let .status(batteryPercentage, thermalState) = response else {
+            guard case let .status(batteryPercentage, thermalState, temperatureCelsius) = response else {
                 return
             }
             self.batteryPercentage = batteryPercentage
             self.thermalState = thermalState
+            self.temperatureCelsius = temperatureCelsius
         } onError: { error in
             logger.info("moblink-streamer: \(self.name): Status failed with \(error)")
         }
@@ -295,10 +297,10 @@ class MoblinkStreamer: NSObject, @unchecked Sendable {
         }
     }
 
-    func getStatuses() -> [(String, Int?, MoblinkThermalState?)] {
+    func getStatuses() -> [(String, Int?, MoblinkThermalState?, Int?)] {
         relays
             .sorted(by: { $0.name < $1.name })
-            .map { ($0.name, $0.batteryPercentage, $0.thermalState) }
+            .map { ($0.name, $0.batteryPercentage, $0.thermalState, $0.temperatureCelsius) }
     }
 
     func updateStatus() {

--- a/Moblin/Various/Model/Model.swift
+++ b/Moblin/Various/Model/Model.swift
@@ -1315,7 +1315,8 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
 
     func formatDeviceStatus(name: String,
                             batteryPercentage: Int?,
-                            thermalState: MoblinkThermalState?) -> (String, Bool)
+                            thermalState: MoblinkThermalState?,
+                            temperatureCelsius: Int? = nil) -> (String, Bool)
     {
         var ok = true
         var status = name
@@ -1333,6 +1334,9 @@ final class Model: NSObject, ObservableObject, @unchecked Sendable {
             } else {
                 status += "🔋\(batteryPercentage)%"
             }
+        }
+        if let temperatureCelsius {
+            status += "🌡️\(temperatureCelsius)°C"
         }
         return (status, ok)
     }

--- a/Moblin/Various/Model/ModelMoblink.swift
+++ b/Moblin/Various/Model/ModelMoblink.swift
@@ -165,10 +165,11 @@ extension Model {
         }
         var statuses: [String] = []
         var ok = true
-        for (name, batteryPercentage, thermalState) in streamer.getStatuses() {
+        for (name, batteryPercentage, thermalState, temperatureCelsius) in streamer.getStatuses() {
             let (status, deviceOk) = formatDeviceStatus(name: name,
                                                         batteryPercentage: batteryPercentage,
-                                                        thermalState: thermalState)
+                                                        thermalState: thermalState,
+                                                        temperatureCelsius: temperatureCelsius)
             if !deviceOk {
                 ok = false
             }

--- a/MoblinTests/Moblin/MoblinkProtocolSuite.swift
+++ b/MoblinTests/Moblin/MoblinkProtocolSuite.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import Moblin
+import Testing
+
+struct MoblinkProtocolSuite {
+    @Test
+    func statusWithTemperatureRoundTrips() throws {
+        let message = MoblinkMessageToStreamer.response(
+            id: 1,
+            result: .ok,
+            data: .status(
+                batteryPercentage: 100,
+                thermalState: nil,
+                temperatureCelsius: 38
+            )
+        )
+        let json = try message.toJson()
+        #expect(json.contains(#""temperatureCelsius":38"#))
+
+        let decoded = try MoblinkMessageToStreamer.fromJson(data: json)
+        guard case let .response(id, result, data) = decoded else {
+            Issue.record("Not a response")
+            return
+        }
+        #expect(id == 1)
+        guard case .ok = result else {
+            Issue.record("Result is not ok")
+            return
+        }
+        guard let data,
+              case let .status(batteryPercentage, thermalState, temperatureCelsius) = data
+        else {
+            Issue.record("Not a status response")
+            return
+        }
+        #expect(batteryPercentage == 100)
+        #expect(thermalState == nil)
+        #expect(temperatureCelsius == 38)
+    }
+
+    @Test
+    func legacyStatusWithoutTemperatureDecodes() throws {
+        let json = #"{"response":{"data":{"status":{"batteryPercentage":100}},"id":1,"result":{"ok":{}}}}"#
+        let decoded = try MoblinkMessageToStreamer.fromJson(data: json)
+        guard case let .response(_, _, data) = decoded,
+              let data,
+              case let .status(batteryPercentage, thermalState, temperatureCelsius) = data
+        else {
+            Issue.record("Not a status response")
+            return
+        }
+        #expect(batteryPercentage == 100)
+        #expect(thermalState == nil)
+        #expect(temperatureCelsius == nil)
+    }


### PR DESCRIPTION
## Goal

Add optional temperature reporting for Moblink relays.

Moblink relays can include `temperatureCelsius` in their status response alongside battery percentage and thermal state.

Example relay status:

```json
{"batteryPercentage":100,"temperatureCelsius":38}
```

The temperature is displayed in the Moblin status UI as:

```text
🌡️38°C
```

## Compatibility

`temperatureCelsius` is optional.

The protocol test covers:

* status responses containing temperature
* legacy status responses without temperature

Swift's synthesized `Codable` keeps this backwards compatible: new Moblin builds can decode legacy relay responses, while older Moblin builds ignore the additional field.

## Relay-side testing

This is currently running on a GL.iNet XE3000 using a modified `moblink-rust` build.

Related moblink-rust changes:

https://github.com/fojd/moblink-rust/commit/53c09b9ef225d62fb1a15f36c38c11f4576d742e

https://github.com/fojd/moblink-rust/commit/f678136d30c618a4b8ee9a812b8702ba648e17c0

The XE3000 currently reports:

```json
{"batteryPercentage":100,"temperatureCelsius":38}
```
